### PR TITLE
Support YouTube HLS to play live streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ let stream = try await YouTube(videoID: "9bZkp7q19f0").streams
 let streamURL = stream.url
 ```
 
+### Example 3
+To get the HLS url for a given YouTube ID:
+```swift
+let hlsManifestUrl = try await YouTube(videoID: "21X5lGlDOfg").hlsManifestUrl
+```

--- a/Sources/YouTubeKit/Extraction.swift
+++ b/Sources/YouTubeKit/Extraction.swift
@@ -199,14 +199,20 @@ class Extraction {
             let status: Status?
             let reason: String?
             let messages: [String]?
-            let liveStreamability: Bool?
-            
+            let liveStreamability: LiveStreamabilityRenderer?
+
             enum Status: String, Decodable {
                 case ok = "OK"
                 case unplayable = "UNPLAYABLE"
                 case loginRequired = "LOGIN_REQUIRED"
                 case error = "ERROR"
                 case liveStream = "LIVE_STREAM"
+            }
+
+            struct LiveStreamabilityRenderer: Decodable {
+                let videoId: String?
+                let broadcastId: Int?
+                let pillDelayMs: Int?
             }
         }
     }

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -158,7 +158,7 @@ class InnerTube {
             let itag: Int
             var url: String?
             let mimeType: String
-            let bitrate: Int
+            let bitrate: Int?
             let width: Int?
             let height: Int?
             let lastModified: String?

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -152,6 +152,7 @@ class InnerTube {
         let formats: [Format]?
         let adaptiveFormats: [Format]? // actually slightly different Format object (TODO)
         let onesieStreamingUrl: String?
+        let hlsManifestUrl: String?
         
         struct Format: Decodable {
             let itag: Int

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -189,6 +189,13 @@ public class YouTube {
         }
     }
     
+    /// The URL of the HLS (HTTP Live Streaming) manifest.
+    public var hlsManifestUrl: String? {
+        get async throws {
+            return try await streamingData.hlsManifestUrl
+        }
+    }
+
     /// streaming data from video info
     var streamingData: InnerTube.StreamingData {
         get async throws {

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -92,7 +92,8 @@ public class YouTube {
     /// check whether the video is available
     public func checkAvailability() async throws {
         let (status, messages) = try Extraction.playabilityStatus(watchHTML: await watchHTML)
-        
+        let streamingData = try await videoInfo.streamingData
+
         for reason in messages {
             switch status {
             case .unplayable:
@@ -105,9 +106,9 @@ public class YouTube {
                 }
             case .error:
                 throw YouTubeKitError.videoUnavailable
-            case .liveStream:
+            case .liveStream where streamingData?.hlsManifestUrl == nil :
                 throw YouTubeKitError.liveStreamError
-            case .ok, .none:
+            case .ok, .none, .liveStream:
                 continue
             }
         }

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -115,6 +115,16 @@ final class YouTubeKitTests: XCTestCase {
         }
     }
     
+    func testHlsManifestUrl() async {
+        let youtube = YouTube(videoID: "21X5lGlDOfg")
+        do {
+            let url = try await youtube.streamingData.hlsManifestUrl
+            XCTAssertTrue(url!.contains(".m3u8"))
+        } catch let error {
+            XCTFail("did throw error: \(error)")
+        }
+    }
+    
     
     // MARK: - Performance Measurement
     

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -125,7 +125,19 @@ final class YouTubeKitTests: XCTestCase {
         }
     }
     
+    func testStreamsAndHlsManifestUrl() async {
+        let youtube = YouTube(videoID: "21X5lGlDOfg")
+        do {
+            let streams = try await youtube.streams
+            let url = try await youtube.streamingData.hlsManifestUrl
+            XCTAssertTrue(url!.contains(".m3u8"))
+            XCTAssertTrue(streams.count > 0)
+        } catch {
+            XCTFail("did throw error: \(error)")
+        }
+    }
     
+
     // MARK: - Performance Measurement
     
     func testObjectParsingFromStartpoint() {


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to play live content in HLS format.

<img src="https://github.com/alexeichhorn/YouTubeKit/assets/3347810/2e1718e5-a296-420d-9046-f350cfb1cce8" width="300" alt="Image 1">
<img src="https://github.com/alexeichhorn/YouTubeKit/assets/3347810/87b6806a-9fc5-45ef-bbfb-9da31a90222f" width="300" alt="Image 2">


## Changes made

- Added the `hlsManifestUrl` property to the `InnerTube` component.
- Exposed the `hlsManifestUrl` property through the YouTube class, allowing easy access to the HLS manifest URL.
- Introduced the `LiveStreamabilityRenderer` to handle live streaming capabilities in the application. This renderer is not a `Boolean` anymore.
- Updated the `README.md` file to reflect the latest improvements.


## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).