### PR TITLE
Support YouTube metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ let audioOnlyStreams = streams.filterAudioOnly()  // all streams without video t
 let videoOnlyStreams = streams.filterVideoOnly()  // all streams without audio track
 ```
 
+4. Retrieve metadata:
+```swift
+let metadata = try await video.metadata
+```
+This will return a `YouTubeMetadata` object.
+
 
 ### Example 1
 To get the video url of type mp4 with the highest available resolution for a given YouTube url:

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -151,6 +151,7 @@ class InnerTube {
 
         struct VideoDetails: Decodable {
             let title: String
+            let shortDescription: String
         }
     }
     

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -142,12 +142,17 @@ class InnerTube {
     struct VideoInfo: Decodable {
         let playabilityStatus: PlayabilityStatus?
         let streamingData: StreamingData?
-        
+        let videoDetails: VideoDetails?
+
         struct PlayabilityStatus: Decodable {
             let status: String?
             let reason: String?
         }
-    }    
+
+        struct VideoDetails: Decodable {
+            let title: String
+        }
+    }
     
     struct StreamingData: Decodable {
         let expiresInSeconds: String?

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -152,6 +152,17 @@ class InnerTube {
         struct VideoDetails: Decodable {
             let title: String
             let shortDescription: String
+            let thumbnail: Thumbnail
+
+            struct Thumbnail: Decodable {
+                let thumbnails: [ThumbnailMetadata]
+
+                struct ThumbnailMetadata: Decodable {
+                    let url: URL
+                    let width: Int
+                    let height: Int
+                }
+            }
         }
     }
     

--- a/Sources/YouTubeKit/Models/Livestream.swift
+++ b/Sources/YouTubeKit/Models/Livestream.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-@available(iOS 13.0, watchOS 6.0, tvOS 13.0, macOS 10.15, *)
 public struct Livestream {
     public enum StreamType {
         case hls
@@ -15,7 +14,4 @@ public struct Livestream {
     
     public let url: URL
     public let streamType: StreamType
-    public var metadata: YouTubeMetadata { .metadata(from: videoDetails) }
-    
-    let videoDetails: InnerTube.VideoInfo.VideoDetails
 }

--- a/Sources/YouTubeKit/Models/Livestream.swift
+++ b/Sources/YouTubeKit/Models/Livestream.swift
@@ -15,13 +15,7 @@ public struct Livestream {
     
     public let url: URL
     public let streamType: StreamType
-    public var metadata: YouTubeMetadata {
-        .init(
-            title: videoDetails.title,
-            description: videoDetails.shortDescription,
-            thumbnail: videoDetails.thumbnail.thumbnails.map { YouTubeMetadata.Thumbnail(url: $0.url) }.last
-        )
-    }
+    public var metadata: YouTubeMetadata { .metadata(from: videoDetails) }
     
     let videoDetails: InnerTube.VideoInfo.VideoDetails
 }

--- a/Sources/YouTubeKit/Models/Livestream.swift
+++ b/Sources/YouTubeKit/Models/Livestream.swift
@@ -7,13 +7,21 @@
 
 import Foundation
 
+@available(iOS 13.0, watchOS 6.0, tvOS 13.0, macOS 10.15, *)
 public struct Livestream {
-    
     public enum StreamType {
         case hls
     }
     
     public let url: URL
     public let streamType: StreamType
+    public var metadata: YouTubeMetadata {
+        .init(
+            title: videoDetails.title,
+            description: videoDetails.shortDescription,
+            thumbnail: videoDetails.thumbnail.thumbnails.map { YouTubeMetadata.Thumbnail(url: $0.url) }.last
+        )
+    }
     
+    let videoDetails: InnerTube.VideoInfo.VideoDetails
 }

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -43,7 +43,11 @@ public struct Stream {
         
         self.fileExtension = FileExtension(mimeType: self.mimeType)
 
-        self.metadata = YouTubeMetadata(title: videoDetails.title, description: videoDetails.shortDescription)
+        self.metadata = YouTubeMetadata(
+            title: videoDetails.title,
+            description: videoDetails.shortDescription,
+            thumbnail: videoDetails.thumbnail.thumbnails.map { YouTubeMetadata.Thumbnail(url: $0.url) }.last
+        )
 
         self.bitrate = format.bitrate
         self.averageBitrate = format.averageBitrate

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -43,7 +43,7 @@ public struct Stream {
         
         self.fileExtension = FileExtension(mimeType: self.mimeType)
 
-        self.metadata = YouTubeMetadata(title: videoDetails.title)
+        self.metadata = YouTubeMetadata(title: videoDetails.title, description: videoDetails.shortDescription)
 
         self.bitrate = format.bitrate
         self.averageBitrate = format.averageBitrate

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -18,7 +18,9 @@ public struct Stream {
     public let subtype: String
     
     public let fileExtension: FileExtension
-    
+
+    public let metadata: YouTubeMetadata
+
     public let bitrate: Int?
     public let averageBitrate: Int?
     public let isDash: Bool
@@ -40,7 +42,9 @@ public struct Stream {
         self.subtype = mimeTypeComponents[safe: 1] ?? ""
         
         self.fileExtension = FileExtension(mimeType: self.mimeType)
-        
+
+        self.metadata = YouTubeMetadata(title: "")
+
         self.bitrate = format.bitrate
         self.averageBitrate = format.averageBitrate
         self.filesize = format.contentLength.flatMap { Int($0) }

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -43,11 +43,7 @@ public struct Stream {
         
         self.fileExtension = FileExtension(mimeType: self.mimeType)
 
-        self.metadata = YouTubeMetadata(
-            title: videoDetails.title,
-            description: videoDetails.shortDescription,
-            thumbnail: videoDetails.thumbnail.thumbnails.map { YouTubeMetadata.Thumbnail(url: $0.url) }.last
-        )
+        self.metadata = .metadata(from: videoDetails)
 
         self.bitrate = format.bitrate
         self.averageBitrate = format.averageBitrate

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -27,7 +27,7 @@ public struct Stream {
     
     private let filesize: Int?
     
-    init(format: InnerTube.StreamingData.Format) throws {
+    init(format: InnerTube.StreamingData.Format, videoDetails: InnerTube.VideoInfo.VideoDetails) throws {
         guard let url = format.url.flatMap({ URL(string: $0) }),
               let itag = ITag(format.itag) else {
             throw YouTubeKitError.extractError
@@ -43,7 +43,7 @@ public struct Stream {
         
         self.fileExtension = FileExtension(mimeType: self.mimeType)
 
-        self.metadata = YouTubeMetadata(title: "")
+        self.metadata = YouTubeMetadata(title: videoDetails.title)
 
         self.bitrate = format.bitrate
         self.averageBitrate = format.averageBitrate

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -18,16 +18,14 @@ public struct Stream {
     public let subtype: String
     
     public let fileExtension: FileExtension
-
-    public let metadata: YouTubeMetadata
-
+    
     public let bitrate: Int?
     public let averageBitrate: Int?
     public let isDash: Bool
     
     private let filesize: Int?
     
-    init(format: InnerTube.StreamingData.Format, videoDetails: InnerTube.VideoInfo.VideoDetails) throws {
+    init(format: InnerTube.StreamingData.Format) throws {
         guard let url = format.url.flatMap({ URL(string: $0) }),
               let itag = ITag(format.itag) else {
             throw YouTubeKitError.extractError
@@ -42,9 +40,7 @@ public struct Stream {
         self.subtype = mimeTypeComponents[safe: 1] ?? ""
         
         self.fileExtension = FileExtension(mimeType: self.mimeType)
-
-        self.metadata = .metadata(from: videoDetails)
-
+        
         self.bitrate = format.bitrate
         self.averageBitrate = format.averageBitrate
         self.filesize = format.contentLength.flatMap { Int($0) }

--- a/Sources/YouTubeKit/Models/YouTubeMetadata.swift
+++ b/Sources/YouTubeKit/Models/YouTubeMetadata.swift
@@ -15,4 +15,13 @@ public struct YouTubeMetadata {
     public struct Thumbnail {
         public let url: URL
     }
+
+    @available(iOS 13.0, *)
+    static func metadata(from videoDetails: InnerTube.VideoInfo.VideoDetails) -> Self {
+        YouTubeMetadata(
+            title: videoDetails.title,
+            description: videoDetails.shortDescription,
+            thumbnail: videoDetails.thumbnail.thumbnails.map { YouTubeMetadata.Thumbnail(url: $0.url) }.last
+        )
+    }
 }

--- a/Sources/YouTubeKit/Models/YouTubeMetadata.swift
+++ b/Sources/YouTubeKit/Models/YouTubeMetadata.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct YouTubeMetadata {
-    
+public struct YouTubeMetadata {
+    public let title: String
 }

--- a/Sources/YouTubeKit/Models/YouTubeMetadata.swift
+++ b/Sources/YouTubeKit/Models/YouTubeMetadata.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public struct YouTubeMetadata {
     public let title: String
+    public let description: String
 }

--- a/Sources/YouTubeKit/Models/YouTubeMetadata.swift
+++ b/Sources/YouTubeKit/Models/YouTubeMetadata.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct YouTubeMetadata {
     public let title: String
     public let description: String
+    public let thumbnail: Thumbnail?
+
+    public struct Thumbnail {
+        public let url: URL
+    }
 }

--- a/Sources/YouTubeKit/Models/YouTubeMetadata.swift
+++ b/Sources/YouTubeKit/Models/YouTubeMetadata.swift
@@ -7,15 +7,28 @@
 
 import Foundation
 
+/// Represents metadata for a YouTube video.
 public struct YouTubeMetadata {
+    /// The title of the YouTube video.
     public let title: String
+
+    /// The description of the YouTube video.
     public let description: String
+
+    /// The thumbnail image of the YouTube video, if available.
     public let thumbnail: Thumbnail?
 
+    /// Represents a YouTube video thumbnail.
     public struct Thumbnail {
+        /// The URL of the thumbnail image.
         public let url: URL
     }
 
+    /// Initialize YouTubeMetadata from video details.
+    ///
+    /// - Parameters:
+    ///   - videoDetails: The video details from InnerTube.VideoInfo.VideoDetails.
+    /// - Returns: A YouTubeMetadata instance.
     @available(iOS 13.0, *)
     static func metadata(from videoDetails: InnerTube.VideoInfo.VideoDetails) -> Self {
         YouTubeMetadata(

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -197,8 +197,9 @@ public class YouTube {
     public var livestreams: [Livestream] {
         get async throws {
             var livestreams = [Livestream]()
-            if let hlsManifestUrl = try await streamingData.hlsManifestUrl.flatMap({ URL(string: $0) }) {
-                livestreams.append(Livestream(url: hlsManifestUrl, streamType: .hls))
+            if let hlsManifestUrl = try await streamingData.hlsManifestUrl.flatMap({ URL(string: $0) }),
+               let videoDetails = try await videoInfo.videoDetails {
+                livestreams.append(Livestream(url: hlsManifestUrl, streamType: .hls, videoDetails: videoDetails))
             }
             return livestreams
         }

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -183,8 +183,11 @@ public class YouTube {
                 try await Extraction.applySignature(streamManifest: &streamManifest, videoInfo: videoInfo, js: js)
             }
             
-            let result = streamManifest.compactMap { try? Stream(format: $0) }
-            
+            let result = streamManifest.compactMap { (format: InnerTube.StreamingData.Format) -> Stream? in
+                guard let details = _videoInfo?.videoDetails else { return nil }
+                return try? Stream(format: format, videoDetails: details)
+            }
+
             _fmtStreams = result
             return result
         }
@@ -213,6 +216,17 @@ public class YouTube {
                 } else {
                     throw YouTubeKitError.extractError
                 }
+            }
+        }
+    }
+
+    /// Video details from video info.
+    var videoDetails: InnerTube.VideoInfo.VideoDetails {
+        get async throws {
+            if let videoDetails = try await videoInfo.videoDetails {
+                return videoDetails
+            } else {
+                throw YouTubeKitError.extractError
             }
         }
     }

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -188,10 +188,7 @@ public class YouTube {
                 try await Extraction.applySignature(streamManifest: &streamManifest, videoInfo: videoInfo, js: js)
             }
             
-            let result = streamManifest.compactMap { (format: InnerTube.StreamingData.Format) -> Stream? in
-                guard let details = _videoInfo?.videoDetails else { return nil }
-                return try? Stream(format: format, videoDetails: details)
-            }
+            let result = streamManifest.compactMap { try? Stream(format: $0) }
 
             _fmtStreams = result
             return result
@@ -202,9 +199,8 @@ public class YouTube {
     public var livestreams: [Livestream] {
         get async throws {
             var livestreams = [Livestream]()
-            if let hlsManifestUrl = try await streamingData.hlsManifestUrl.flatMap({ URL(string: $0) }),
-               let videoDetails = try await videoInfo.videoDetails {
-                livestreams.append(Livestream(url: hlsManifestUrl, streamType: .hls, videoDetails: videoDetails))
+            if let hlsManifestUrl = try await streamingData.hlsManifestUrl.flatMap({ URL(string: $0) }) {
+                livestreams.append(Livestream(url: hlsManifestUrl, streamType: .hls))
             }
             return livestreams
         }

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -26,8 +26,13 @@ public class YouTube {
     private var _fmtStreams: [Stream]?
     
     private var initialData: Data?
-    private var metadata: YouTubeMetadata?
-    
+    public var metadata: YouTubeMetadata? {
+        get async throws {
+            guard let videoDetails = try await videoInfo.videoDetails else { return nil }
+            return .metadata(from: videoDetails)
+        }
+    }
+
     public let videoID: String
     
     var watchURL: URL {

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -26,6 +26,10 @@ public class YouTube {
     private var _fmtStreams: [Stream]?
     
     private var initialData: Data?
+
+    /// Represents a property that provides metadata for a YouTube video.
+    ///
+    /// This property allows you to retrieve metadata for a YouTube video asynchronously.
     public var metadata: YouTubeMetadata? {
         get async throws {
             guard let videoDetails = try await videoInfo.videoDetails else { return nil }

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -140,6 +140,18 @@ final class YouTubeKitTests: XCTestCase {
         }
     }
     
+    func testMetadataLive() async {
+        let youtube = YouTube(videoID: "Z-Nwo-ypKtM")
+        do {
+            let stream = try await youtube.livestreams.first!
+            XCTAssertEqual(stream.metadata.title, "franceinfo - DIRECT TV - actualité france et monde, interviews, documentaires et analyses")
+            XCTAssertFalse(stream.metadata.description.isEmpty)
+            XCTAssertNotNil(stream.metadata.thumbnail!.url)
+        } catch let error {
+            XCTFail("did throw error: \(error)")
+        }
+    }
+    
 
     // MARK: - Performance Measurement
     

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -128,25 +128,25 @@ final class YouTubeKitTests: XCTestCase {
         }
     }
     
-    func testMetadata() async {
+    func testMetadataForOnDemand() async {
         let youtube = YouTube(videoID: "ApM_KEr1ktQ")
         do {
-            let stream = try await youtube.streams.first!
-            XCTAssertEqual(stream.metadata.title, "Le Maroc Vu du Ciel (Documentaire)")
-            XCTAssertFalse(stream.metadata.description.isEmpty)
-            XCTAssertEqual(stream.metadata.thumbnail!.url, URL(string: "https://i.ytimg.com/vi/ApM_KEr1ktQ/sddefault.jpg"))
+            let metadata = try await youtube.metadata!
+            XCTAssertEqual(metadata.title, "Le Maroc Vu du Ciel (Documentaire)")
+            XCTAssertFalse(metadata.description.isEmpty)
+            XCTAssertEqual(metadata.thumbnail!.url, URL(string: "https://i.ytimg.com/vi/ApM_KEr1ktQ/sddefault.jpg"))
         } catch let error {
             XCTFail("did throw error: \(error)")
         }
     }
     
-    func testMetadataLive() async {
+    func testMetadataForLive() async {
         let youtube = YouTube(videoID: "Z-Nwo-ypKtM")
         do {
-            let stream = try await youtube.livestreams.first!
-            XCTAssertEqual(stream.metadata.title, "franceinfo - DIRECT TV - actualité france et monde, interviews, documentaires et analyses")
-            XCTAssertFalse(stream.metadata.description.isEmpty)
-            XCTAssertNotNil(stream.metadata.thumbnail!.url)
+            let metadata = try await youtube.metadata!
+            XCTAssertEqual(metadata.title, "franceinfo - DIRECT TV - actualité france et monde, interviews, documentaires et analyses")
+            XCTAssertFalse(metadata.description.isEmpty)
+            XCTAssertNotNil(metadata.thumbnail!.url)
         } catch let error {
             XCTFail("did throw error: \(error)")
         }

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -131,8 +131,9 @@ final class YouTubeKitTests: XCTestCase {
     func testMetadata() async {
         let youtube = YouTube(videoID: "ApM_KEr1ktQ")
         do {
-            let stream = try await youtube.streams.first
-            XCTAssertEqual(stream?.metadata.title, "Le Maroc Vu du Ciel (Documentaire)")
+            let stream = try await youtube.streams.first!
+            XCTAssertEqual(stream.metadata.title, "Le Maroc Vu du Ciel (Documentaire)")
+            XCTAssertFalse(stream.metadata.description.isEmpty)
         } catch let error {
             XCTFail("did throw error: \(error)")
         }

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -134,6 +134,7 @@ final class YouTubeKitTests: XCTestCase {
             let stream = try await youtube.streams.first!
             XCTAssertEqual(stream.metadata.title, "Le Maroc Vu du Ciel (Documentaire)")
             XCTAssertFalse(stream.metadata.description.isEmpty)
+            XCTAssertEqual(stream.metadata.thumbnail!.url, URL(string: "https://i.ytimg.com/vi/ApM_KEr1ktQ/sddefault.jpg"))
         } catch let error {
             XCTFail("did throw error: \(error)")
         }

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -128,6 +128,16 @@ final class YouTubeKitTests: XCTestCase {
         }
     }
     
+    func testMetadata() async {
+        let youtube = YouTube(videoID: "ApM_KEr1ktQ")
+        do {
+            let stream = try await youtube.streams.first
+            XCTAssertEqual(stream?.metadata.title, "Le Maroc Vu du Ciel (Documentaire)")
+        } catch let error {
+            XCTFail("did throw error: \(error)")
+        }
+    }
+    
 
     // MARK: - Performance Measurement
     


### PR DESCRIPTION
# Pull Request

## Description

This PR enables us to retrieve video metadata, including the title, a short description, and a thumbnail.

## Related Issues

- #11
- #23

## Changes Made

- `VideoDetails` has been added to `VideoInfo` to fetch **YouTube** metadata.
- `YouTubeMetadata` has been made public with three properties: `title`, `description`, and `thumbnail`.
- `YouTubeMetadata.Thumbnail` has been introduced.
- Two new tests have been added:
  - `testMetadataForOnDemand`
  - `testMetadataForLive`

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] Documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
