### PR TITLE
Add gitattributes to ignore vendored JavaScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude bundled JavaScript helper files from GitHub language statistics
+Sources/YouTubeKit/Resources/*.js linguist-vendored


### PR DESCRIPTION
## Summary
- mark bundled JavaScript helpers as vendored so Swift remains the primary language reported by GitHub

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690148d29d18832596ba7ff10d3ab102