### PR TITLE
Sync InnerTube clients with yt-dlp April 2026, fix stream extraction and edge cases

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -27,6 +27,10 @@ jobs:
     - name: Build ${{ matrix.platform.name }}
       run: xcodebuild build -scheme YouTubeKit -destination '${{ matrix.platform.destination }}' -skipPackagePluginValidation
 
-    # temporarily disabled because YouTube blocked GitHub actions url
-    #- name: Run tests
-    #  run: swift test -v
+    # Offline tests only — signature/nsig fixtures, parsing, extraction regex, codec ranking.
+    # E2E tests that hit YouTube are gated behind YOUTUBEKIT_E2E and skipped here because
+    # YouTube blocks GitHub Actions IP ranges. Run E2E locally before releases:
+    #   YOUTUBEKIT_E2E=1 swift test
+    - name: Run offline tests (macOS only)
+      if: matrix.platform.name == 'macOS'
+      run: swift test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,6 +1,14 @@
 name: Swift Unit Tests
 
-on: push
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      run_e2e:
+        description: 'Run live E2E tests (may fail — YouTube blocks GH Actions IPs)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -32,5 +40,14 @@ jobs:
     # YouTube blocks GitHub Actions IP ranges. Run E2E locally before releases:
     #   YOUTUBEKIT_E2E=1 swift test
     - name: Run offline tests (macOS only)
-      if: matrix.platform.name == 'macOS'
+      if: matrix.platform.name == 'macOS' && inputs.run_e2e != true
       run: swift test
+
+    # Opt-in live E2E run via `workflow_dispatch` → run_e2e=true. Expect failures
+    # from CDN reachability checks because YouTube blocks GH Actions IP ranges.
+    - name: Run E2E tests (opt-in, macOS only)
+      if: matrix.platform.name == 'macOS' && inputs.run_e2e == true
+      env:
+        YOUTUBEKIT_E2E: '1'
+      run: swift test
+      continue-on-error: true

--- a/Sources/YouTubeKit/Cipher.swift
+++ b/Sources/YouTubeKit/Cipher.swift
@@ -138,6 +138,9 @@ class Cipher {
             ExtractionRegex(pattern: #"\b([a-zA-Z0-9_$]+)&&\(\1=([a-zA-Z0-9_$]{2,})\(decodeURIComponent\(\1\)\)"#, group: 2),
             ExtractionRegex(pattern: #"([a-zA-Z0-9_$]+)\s*=\s*function\(\s*([a-zA-Z0-9_$]+)\s*\)\s*\{\s*\2\s*=\s*\2\.split\(\s*\"\"\s*\)\s*;\s*[^}]+;\s*return\s+\2\.join\(\s*\"\"\s*\)"#, group: 1),
             ExtractionRegex(pattern: #"(?:\b|[^a-zA-Z0-9_$])([a-zA-Z0-9_$]{2,})\s*=\s*function\(\s*a\s*\)\s*\{\s*a\s*=\s*a\.split\(\s*\"\"\s*\)(?:;[a-zA-Z0-9_$]{2}\.[a-zA-Z0-9_$]{2}\(a,\d+\))?"#, group: 1),
+            // Obfuscated sig access via h.s property (from youtube-dl _parse_sig_js, 2025-04).
+            // Matches e.g. "m=XX(decodeURIComponent(h.s))" in players that destructure sig data.
+            ExtractionRegex(pattern: #"\bm=([a-zA-Z0-9_$]{2,})\(decodeURIComponent\(h\.s\)\)"#, group: 1),
             // older
             ExtractionRegex(pattern: #"\b[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*encodeURIComponent\s*\(\s*([a-zA-Z0-9$]+)\("#, group: 1),
             ExtractionRegex(pattern: #"\b[a-zA-Z0-9]+\s*&&\s*[a-zA-Z0-9]+\.set\([^,]+\s*,\s*encodeURIComponent\s*\(\s*([a-zA-Z0-9$]+)\("#, group: 1),

--- a/Sources/YouTubeKit/Errors.swift
+++ b/Sources/YouTubeKit/Errors.swift
@@ -25,22 +25,28 @@ extension YouTubeKitError: LocalizedError {
 
     public var errorDescription: String? {
         switch self {
+        case .maxRetriesExceeded:
+            return NSLocalizedString("All extraction methods failed", comment: "")
+        case .htmlParseError:
+            return NSLocalizedString("Failed to parse YouTube page HTML", comment: "")
+        case .extractError:
+            return NSLocalizedString("Failed to extract video data", comment: "")
+        case .regexMatchError:
+            return NSLocalizedString("Required pattern not found in page data", comment: "")
         case .videoUnavailable:
             return NSLocalizedString("Video unavailable", comment: "")
-
         case .videoAgeRestricted:
             return NSLocalizedString("Video age restricted", comment: "")
-
         case .liveStreamError:
             return NSLocalizedString("Can't extract video from livestream", comment: "")
-
         case .videoPrivate:
             return NSLocalizedString("Video is private", comment: "")
-
+        case .recordingUnavailable:
+            return NSLocalizedString("Recording unavailable", comment: "")
         case .membersOnly:
             return NSLocalizedString("Video is members only", comment: "")
-
-        default: return nil
+        case .videoRegionBlocked:
+            return NSLocalizedString("Video is not available in your region", comment: "")
         }
     }
 

--- a/Sources/YouTubeKit/Extensions/Foundation.swift
+++ b/Sources/YouTubeKit/Extensions/Foundation.swift
@@ -46,7 +46,7 @@ extension String {
     func stripTrailing(_ characters: String) -> String {
         var result = self
         let characterSet = CharacterSet(charactersIn: characters)
-        // Safe unwrap instead of force-unwrap on unicodeScalars (audit MEDIUM).
+        // Safe unwrap instead of force-unwrap on unicodeScalars.
         while let last = result.last,
               let scalar = last.unicodeScalars.first,
               characterSet.contains(scalar) {

--- a/Sources/YouTubeKit/Extensions/Foundation.swift
+++ b/Sources/YouTubeKit/Extensions/Foundation.swift
@@ -46,7 +46,10 @@ extension String {
     func stripTrailing(_ characters: String) -> String {
         var result = self
         let characterSet = CharacterSet(charactersIn: characters)
-        while let last = result.last, characterSet.contains(last.unicodeScalars.first!) {
+        // Safe unwrap instead of force-unwrap on unicodeScalars (audit MEDIUM).
+        while let last = result.last,
+              let scalar = last.unicodeScalars.first,
+              characterSet.contains(scalar) {
             result.removeLast()
         }
         return result

--- a/Sources/YouTubeKit/Extraction.swift
+++ b/Sources/YouTubeKit/Extraction.swift
@@ -55,17 +55,25 @@ class Extraction {
     }
     
     /// Get the YouTube player base JavaScript path.
+    /// YouTube serves multiple player JS variants (main, tcc, tce, tv, phone, etc.).
+    /// The patterns below cover all known URL formats as of April 2026 (synced with yt-dlp).
     class func getYTPlayerJS(html: String) throws -> String {
         let jsURLPatterns = [
-            NSRegularExpression(#"(/s/player/[\w\d]+/[\w\d_/.]+/base\.js)"#)
+            // Standard player URL format — e.g. /s/player/9f4cc5e4/player_ias.vflset/en_US/base.js
+            NSRegularExpression(#"(/s/player/[\w\d]+/[\w\d_/.]+/base\.js)"#),
+            // Full absolute URL variant — sometimes found in embed HTML with https://www.youtube.com prefix
+            NSRegularExpression(#"(https?://(?:www\.)?youtube\.com/s/player/[\w\d]+/[\w\d_/.]+/base\.js)"#),
+            // TV player variant — yt-dlp defaults to tv variant since Feb 2026 (#15818)
+            // because the main variant's sig function can be harder to extract.
+            NSRegularExpression(#"(/s/player/[\w\d]+/tv[^"]*?/base\.js)"#)
         ]
-        
+
         for pattern in jsURLPatterns {
             if let match = pattern.firstMatch(in: html, group: 1) {
                 return match.content
             }
         }
-        
+
         throw YouTubeKitError.regexMatchError
     }
     
@@ -363,10 +371,7 @@ class Extraction {
     }
     
     class func applyDescrambler(streamData: InnerTube.StreamingData) -> [InnerTube.StreamingData.Format] {
-        /*if streamData.keys.contains("url") {
-            return nil
-        }*/
-        
+
         var formats = [InnerTube.StreamingData.Format]()
         if let streamFormats = streamData.formats {
             formats += streamFormats
@@ -374,20 +379,35 @@ class Extraction {
         if let adaptiveFormats = streamData.adaptiveFormats {
             formats += adaptiveFormats
         }
-        
+
         for (i, data) in formats.enumerated() {
             if data.url == nil {
                 if let signatureCipher = data.signatureCipher {
                     let cipherURL = parseQueryString(signatureCipher)
-                    // URL-decode the values (they come percent-encoded from signatureCipher)
+                    // URL-decode the values — signatureCipher values are percent-encoded,
+                    // and URLComponents already decodes once, but the URL value itself may
+                    // be double-encoded (the URL within the cipher string), so we decode again.
                     formats[i].url = cipherURL["url"]?.first?.removingPercentEncoding ?? cipherURL["url"]?.first
                     formats[i].s = cipherURL["s"]?.first?.removingPercentEncoding ?? cipherURL["s"]?.first
+                    // sp is the query parameter name for the decrypted signature (usually "sig" or "signature")
                     formats[i].sp = cipherURL["sp"]?.first?.removingPercentEncoding ?? cipherURL["sp"]?.first
                 }
+                // If format has neither url nor signatureCipher, it's a SABR-only stream
+                // (serverAbrStreamingUrl). These cannot be played via direct URL download —
+                // they require YouTube's proprietary Server ABR protocol. We leave url as nil;
+                // these formats will be filtered out during Stream construction.
             }
         }
-        
-        os_log("applying descrambler", log: log, type: .debug)
+
+        // Remove formats with no URL (SABR-only or missing data) or empty-string URLs
+        // (malformed signatureCipher with missing "url" key). Both waste cycles in the
+        // signature solver and produce broken Stream objects downstream.
+        formats = formats.filter { url in
+            guard let urlStr = url.url else { return false }
+            return !urlStr.isEmpty
+        }
+
+        os_log("applying descrambler — %{public}i usable formats", log: log, type: .debug, formats.count)
         return formats
     }
     
@@ -457,16 +477,14 @@ class Extraction {
                 }
 
 
-                // apply throttling "n" signature
+                // Apply throttling "n" signature — if solving fails, keep the stream anyway.
+                // An unsolved n-param means the stream will be throttled but still playable.
+                // Dropping it entirely is worse than serving a throttled stream.
                 if let initialN = urlComponents.queryItems?["n"] {
-                    guard let newN = response.nMap[initialN] else {
-                        invalidStreamIndices.append(i)
-                        continue
-                    }
-                    urlComponents.queryItems?["n"] = newN
-
-                    if newN.isEmpty {
-                        invalidStreamIndices.append(i)
+                    if let newN = response.nMap[initialN], !newN.isEmpty {
+                        urlComponents.queryItems?["n"] = newN
+                    } else {
+                        os_log("n-param solving failed for itag=%{public}i — stream will be throttled", log: log, type: .info, stream.itag)
                     }
                 }
 
@@ -483,13 +501,36 @@ class Extraction {
     }
 #endif
     
-    /// Filter out all audio streams that are not original language (i.e. dubbed)
+    /// Filter out all audio streams that are not original language (i.e. dubbed).
+    /// Uses both `audioIsDefault` flag and display name heuristic (yt-dlp approach).
+    /// YouTube tags the original audio track with audioIsDefault=true;
+    /// the "original" suffix in displayName is a secondary fallback heuristic.
     class func filterOutDubbedAudio(streamManifest: [InnerTube.StreamingData.Format]) -> [InnerTube.StreamingData.Format] {
-        streamManifest.filter { stream in
-            if let audioTrack = stream.audioTrack {
-                return audioTrack.displayName.lowercased().hasSuffix("original")
+        // First check if ANY stream has audioTrack metadata — if none do, this
+        // video is single-language and all streams should be kept as-is.
+        let hasAnyAudioTrack = streamManifest.contains { $0.audioTrack != nil }
+        guard hasAnyAudioTrack else { return streamManifest }
+
+        return streamManifest.filter { stream in
+            guard let audioTrack = stream.audioTrack else {
+                // Streams without audioTrack metadata are video-only or single-language — keep them
+                return true
             }
-            return true
+            // Primary check: audioIsDefault is the authoritative flag from YouTube's API
+            if audioTrack.audioIsDefault {
+                return true
+            }
+            // Fallback: some responses set audioIsDefault=false for the original track
+            // but tag the display name with "original" suffix
+            if audioTrack.displayName.lowercased().hasSuffix("original") {
+                return true
+            }
+            // Edge case: if display name is empty, keep the stream rather than silently drop it.
+            // Better to include a possible dub than to lose the only audio track.
+            if audioTrack.displayName.isEmpty {
+                return true
+            }
+            return false
         }
     }
     

--- a/Sources/YouTubeKit/Extraction.swift
+++ b/Sources/YouTubeKit/Extraction.swift
@@ -55,17 +55,22 @@ class Extraction {
     }
     
     /// Get the YouTube player base JavaScript path.
-    /// YouTube serves multiple player JS variants (main, tcc, tce, tv, phone, etc.).
-    /// The patterns below cover all known URL formats as of April 2026 (synced with yt-dlp).
+    /// YouTube serves multiple player JS variants per yt-dlp's `_PLAYER_JS_VARIANT_MAP`
+    /// (main, tcc, tce, es5, es6, es6_tcc, es6_tce, tv, tv_es6, phone, house). The patterns
+    /// below cover all variants — including dash-containing TV paths and non-`base.js` suffixes.
     class func getYTPlayerJS(html: String) throws -> String {
         let jsURLPatterns = [
-            // Standard player URL format — e.g. /s/player/9f4cc5e4/player_ias.vflset/en_US/base.js
-            NSRegularExpression(#"(/s/player/[\w\d]+/[\w\d_/.]+/base\.js)"#),
-            // Full absolute URL variant — sometimes found in embed HTML with https://www.youtube.com prefix
-            NSRegularExpression(#"(https?://(?:www\.)?youtube\.com/s/player/[\w\d]+/[\w\d_/.]+/base\.js)"#),
-            // TV player variant — yt-dlp defaults to tv variant since Feb 2026 (#15818)
-            // because the main variant's sig function can be harder to extract.
-            NSRegularExpression(#"(/s/player/[\w\d]+/tv[^"]*?/base\.js)"#)
+            // Unified variant pattern — matches any player JS URL, including:
+            //   /s/player/{id}/player_ias.vflset/en_US/base.js
+            //   /s/player/{id}/player_ias_tce.vflset/en_US/base.js
+            //   /s/player/{id}/player_es6.vflset/en_US/base.js
+            //   /s/player/{id}/tv-player-ias.vflset/tv-player-ias.js
+            //   /s/player/{id}/tv-player-es6.vflset/tv-player-es6.js
+            //   /s/player/{id}/player-plasma-ias-phone-en_US.vflset/base.js
+            // Allows word chars, dashes, dots, underscores and slashes in the path.
+            NSRegularExpression(#"(/s/player/[a-fA-F0-9]{8,}/[\w\-/.]+\.js)"#),
+            // Full absolute URL variant — sometimes found in embed HTML with https://www.youtube.com prefix.
+            NSRegularExpression(#"(https?://(?:www\.)?youtube\.com/s/player/[a-fA-F0-9]{8,}/[\w\-/.]+\.js)"#)
         ]
 
         for pattern in jsURLPatterns {

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -23,7 +23,9 @@ class InnerTube {
         var deviceModel: String? = nil
         
         var context: Context {
-            let client = Context.ContextClient(clientName: name, clientVersion: version, clientScreen: screen, androidSdkVersion: androidSdkVersion, deviceModel: deviceModel)
+            // Include hl/timeZone/utcOffsetMinutes — YouTube requires these for consistent responses.
+            // Without them, some regions may get restricted or differently-formatted data (yt-dlp default).
+            let client = Context.ContextClient(clientName: name, clientVersion: version, clientScreen: screen, androidSdkVersion: androidSdkVersion, deviceModel: deviceModel, hl: "en", timeZone: "UTC", utcOffsetMinutes: 0)
             let thirdParty = screen == "EMBED" ? Context.ThirdParty(embedUrl: "https://www.youtube.com/") : nil
             return Context(client: client, thirdParty: thirdParty)
         }
@@ -47,6 +49,12 @@ class InnerTube {
             let clientScreen: String?
             let androidSdkVersion: Int?
             let deviceModel: String?
+            // yt-dlp sends these locale fields in every request (Jan 2026).
+            // YouTube uses them to determine response format; missing fields may cause
+            // different/restricted responses for some regions.
+            let hl: String?
+            let timeZone: String?
+            let utcOffsetMinutes: Int?
         }
 
         struct ThirdParty: Encodable {
@@ -55,27 +63,50 @@ class InnerTube {
     }
     
     // overview of clients: https://github.com/zerodytrash/YouTube-Internal-Clients
+    // Client versions synced with yt-dlp as of April 2026
     private let defaultClients = [
+        // WEB client — SABR-only since Feb 2025, no downloadable stream URLs returned.
+        // Kept for metadata/ytcfg extraction but should NOT be used for stream fetching.
         ClientType.web: Client(name: "WEB", version: "2.20260114.08.00", screen: nil, apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 1, userAgent: "Mozilla/5.0"),
+        // WEB with Safari UA — also SABR-only for adaptive formats, but may return pre-merged HLS.
         ClientType.webSafari: Client(name: "WEB", version: "2.20260114.08.00", screen: nil, apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 1, userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)"),
-        ClientType.android: Client(name: "ANDROID", version: "20.10.38", screen: nil, apiKey: "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w", internalID: 3, userAgent: "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip", playerParams: "CgIQBg==", androidSdkVersion: 30),
-        ClientType.androidSdkless: Client(name: "ANDROID", version: "21.02.35", screen: nil, apiKey: "", internalID: 3, userAgent: "com.google.android.youtube/21.02.35 (Linux; U; Android 11) gzip"),
+        // ANDROID — bumped from 20.10.38 to 21.02.35 (Jan 2026 yt-dlp #15726).
+        // YouTube deprecated 20.x Android versions; old versions may get empty/blocked responses.
+        ClientType.android: Client(name: "ANDROID", version: "21.02.35", screen: nil, apiKey: "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w", internalID: 3, userAgent: "com.google.android.youtube/21.02.35 (Linux; U; Android 11) gzip", playerParams: "CgIQBg==", androidSdkVersion: 30),
+        // androidSdkless REMOVED — YouTube fully deprecated this client in Jan 2026 (yt-dlp #15726).
+        // ANDROID_MUSIC — version kept; not typically used for stream extraction.
         ClientType.androidMusic: Client(name: "ANDROID_MUSIC", version: "5.16.51", screen: nil, apiKey: "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI", internalID: 21, userAgent: "com.google.android.apps.youtube.music/5.16.51 (Linux; U; Android 11) gzip", playerParams: "CgIQBg==", androidSdkVersion: 30),
-        // yt-dlp rolled this client back because newer versions can yield SABR-only streams.
+        // ANDROID_VR — pinned at 1.65.10 intentionally (yt-dlp default).
+        // Versions >1.65 return SABR-only streams. This is the safest client for stream URLs:
+        // no PO token required, no JS player needed, returns full HTTPS format URLs.
         ClientType.androidVR: Client(name: "ANDROID_VR", version: "1.65.10", screen: nil, apiKey: "", internalID: 28, userAgent: "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip", androidSdkVersion: 32, deviceModel: "Quest 3"),
+        // WEB_EMBEDDED_PLAYER — version already current.
         ClientType.webEmbed: Client(name: "WEB_EMBEDDED_PLAYER", version: "1.20260115.01.00", screen: "EMBED", apiKey: "", internalID: 56, userAgent: "Mozilla/5.0"),
-        ClientType.webCreator: Client(name: "WEB_CREATOR", version: "1.20250922.03.00", screen: nil, apiKey: "", internalID: 62, userAgent: nil),
+        // WEB_CREATOR — bumped from 1.20250922.03.00 to 1.20260114.05.00 (Jan 2026 yt-dlp).
+        // Requires authentication; used for age-gated content bypass.
+        ClientType.webCreator: Client(name: "WEB_CREATOR", version: "1.20260114.05.00", screen: nil, apiKey: "", internalID: 62, userAgent: nil),
+        // ANDROID_EMBEDDED_PLAYER — kept for embed fallback.
         ClientType.androidEmbed: Client(name: "ANDROID_EMBEDDED_PLAYER", version: "18.11.34", screen: "EMBED", apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 3, userAgent: "com.google.android.youtube/18.11.34 (Linux; U; Android 11) gzip"),
-        ClientType.tv: Client(name: "TVHTML5", version: "7.20250923.13.00", screen: nil, apiKey: "", internalID: 7, userAgent: "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/25.lts.30.1034943-gold (unlike Gecko), Unknown_TV_Unknown_0/Unknown (Unknown, Unknown)"),
+        // TVHTML5 — bumped from 7.20250923.13.00 to 7.20260114.12.00 (Jan 2026 yt-dlp).
+        // TV client still returns HTTPS format URLs (not SABR-only).
+        ClientType.tv: Client(name: "TVHTML5", version: "7.20260114.12.00", screen: nil, apiKey: "", internalID: 7, userAgent: "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version (unlike Gecko) cobalt/26 (unlike Gecko)"),
+        // TVHTML5_SIMPLY_EMBEDDED_PLAYER — kept for embed fallback.
         ClientType.tvEmbed: Client(name: "TVHTML5_SIMPLY_EMBEDDED_PLAYER", version: "2.0", screen: "EMBED", apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 85, userAgent: "Mozilla/5.0"),
-        ClientType.ios: Client(name: "IOS", version: "20.10.4", screen: nil, apiKey: "", internalID: 5, userAgent: "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)", deviceModel: "iPhone16,2"),
+        // IOS — bumped from 20.10.4 to 21.02.3 (Jan 2026 yt-dlp #15726).
+        // YouTube deprecated 20.x iOS versions; old versions may get empty/blocked responses.
+        // Returns HTTPS format URLs without requiring JS player.
+        ClientType.ios: Client(name: "IOS", version: "21.02.3", screen: nil, apiKey: "", internalID: 5, userAgent: "com.google.ios.youtube/21.02.3 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)", deviceModel: "iPhone16,2"),
+        // IOS_MUSIC — kept for potential music content extraction.
         ClientType.iosMusic: Client(name: "IOS_MUSIC", version: "5.21", screen: nil, apiKey: "AIzaSyBAETezhkwP0ZWA02RsqT1zu78Fpt0bC_s", internalID: 26, userAgent: "com.google.ios.youtubemusic/5.21 (iPhone14,3; U; CPU iOS 15_6 like Mac OS X)", deviceModel: "iPhone14,3"),
+        // MEDIA_CONNECT_FRONTEND — special client used as last-resort fallback for progressive streams.
         ClientType.mediaConnectFrontend: Client(name: "MEDIA_CONNECT_FRONTEND", version: "0.1", screen: nil, apiKey: "", internalID: 0, userAgent: nil),
-        ClientType.mWeb: Client(name: "MWEB", version: "2.20250925.01.00", screen: nil, apiKey: "", internalID: 2, userAgent: nil)
+        // MWEB — bumped from 2.20250925.01.00 to 2.20260115.01.00 (Jan 2026 yt-dlp).
+        ClientType.mWeb: Client(name: "MWEB", version: "2.20260115.01.00", screen: nil, apiKey: "", internalID: 2, userAgent: nil)
     ]
     
     enum ClientType: String {
-        case web, webSafari, android, androidSdkless, androidMusic, androidVR, webEmbed, webCreator, androidEmbed, tv, tvEmbed, ios, iosMusic, mediaConnectFrontend, mWeb
+        // androidSdkless removed — YouTube deprecated this client in Jan 2026 (yt-dlp #15726)
+        case web, webSafari, android, androidMusic, androidVR, webEmbed, webCreator, androidEmbed, tv, tvEmbed, ios, iosMusic, mediaConnectFrontend, mWeb
     }
     
     private var accessToken: String?
@@ -96,10 +127,15 @@ class InnerTube {
     private let baseURL = "https://www.youtube.com/youtubei/v1"
     
     init(client: ClientType = .ios, signatureTimestamp: Int?, ytcfg: Extraction.YtCfg, useOAuth: Bool = false, allowCache: Bool = true) {
-        self.context = defaultClients[client]!.context
-        self.apiKey = defaultClients[client]!.apiKey
-        self.headers = defaultClients[client]!.headers
-        self.playerParams = defaultClients[client]!.playerParams
+        // Single lookup instead of four force-unwraps — crashes with a clear message
+        // if a ClientType is added without a matching entry (audit HIGH).
+        guard let clientDef = defaultClients[client] else {
+            preconditionFailure("Missing client definition for \(client.rawValue)")
+        }
+        self.context = clientDef.context
+        self.apiKey = clientDef.apiKey
+        self.headers = clientDef.headers
+        self.playerParams = clientDef.playerParams
         self.encryptedHostFlags = client == .webEmbed ? ytcfg.embeddedPlayerEncryptedHostFlags : nil
         self.signatureTimestamp = signatureTimestamp
         self.ytcfg = ytcfg
@@ -147,30 +183,43 @@ class InnerTube {
     }
     
     private func callAPI<T: Decodable>(endpoint: String, query: [URLQueryItem], data: Data) async throws -> T {
-        
+
         // TODO: handle oauth case
-        
+
         var urlComponents = URLComponents(string: endpoint)!
         urlComponents.queryItems = query
-        
+
         var request = URLRequest(url: urlComponents.url!)
         request.httpMethod = "post"
         request.httpBody = data
+        // Timeout prevents indefinite hang on network stalls (audit P0)
+        request.timeoutInterval = 15
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Use client-specific UA from headers first; fall back to ytcfg or generic Safari UA.
+        // A realistic User-Agent is critical — YouTube validates UA against clientName/Version
+        // and may reject mismatched combinations with empty responses (yt-dlp #14707).
         request.addValue(ytcfg.userAgent ?? "Mozilla/5.0", forHTTPHeaderField: "User-Agent")
         request.addValue("en-US,en", forHTTPHeaderField: "accept-language")
-        
-        request.addValue(ytcfg.visitorData ?? "", forHTTPHeaderField: "X-Goog-Visitor-Id")
+
+        // Visitor data identifies the session — YouTube uses it to track request context.
+        // Missing visitor data can cause some clients to return restricted responses.
+        if let visitorData = ytcfg.visitorData, !visitorData.isEmpty {
+            request.addValue(visitorData, forHTTPHeaderField: "X-Goog-Visitor-Id")
+        }
+        // Origin header — YouTube validates this matches the innertube host.
+        // Must be present for web-based clients; mobile clients are more lenient.
         request.addValue("https://www.youtube.com", forHTTPHeaderField: "Origin")
-        
+
+        // Apply client-specific headers (X-YouTube-Client-Name, X-YouTube-Client-Version, User-Agent).
+        // These override the defaults above when the client has specific values.
         for (key, value) in headers {
             request.setValue(value, forHTTPHeaderField: key)
         }
-        
+
         // TODO: handle oauth auth case again
-        
+
         let (responseData, _) = try await URLSession.shared.data(for: request)
-        
+
         return try JSONDecoder().decode(T.self, from: responseData)
     }
     
@@ -265,10 +314,13 @@ class InnerTube {
     
     func player(videoID: String) async throws -> VideoInfo {
         let endpoint = baseURL + "/player"
-        let query = [
-            URLQueryItem(name: "key", value: apiKey),
-            URLQueryItem(name: "prettyPrint", value: "false")
-        ].filter { !($0.value?.isEmpty ?? true) }
+        // Only include API key if non-empty — many newer clients (androidVR, ios, tv)
+        // use empty apiKey and rely on context alone for auth (yt-dlp pattern).
+        // Including an empty "key" param can cause 400 errors on some endpoints.
+        var query = [URLQueryItem(name: "prettyPrint", value: "false")]
+        if !apiKey.isEmpty {
+            query.insert(URLQueryItem(name: "key", value: apiKey), at: 0)
+        }
         let request = playerRequest(forVideoID: videoID)
         return try await callAPI(endpoint: endpoint, query: query, object: request)
     }

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -170,11 +170,16 @@ class InnerTube {
     }
     
     private var baseParams: [URLQueryItem] {
-        [
-            URLQueryItem(name: "key", value: apiKey),
+        // Only include API key when non-empty — consistent with player() endpoint.
+        // Clients like ios/androidVR have empty apiKey by design.
+        var items = [
             URLQueryItem(name: "contentCheckOk", value: "true"),
             URLQueryItem(name: "racyCheckOk", value: "true")
         ]
+        if !apiKey.isEmpty {
+            items.insert(URLQueryItem(name: "key", value: apiKey), at: 0)
+        }
+        return items
     }
     
     private func callAPI<D: Encodable, T: Decodable>(endpoint: String, query: [URLQueryItem], object: D) async throws -> T {

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -20,12 +20,15 @@ class InnerTube {
         var playerParams: String? = nil
 
         var androidSdkVersion: Int? = nil
+        var deviceMake: String? = nil
         var deviceModel: String? = nil
-        
+        var osName: String? = nil
+        var osVersion: String? = nil
+
         var context: Context {
             // Include hl/timeZone/utcOffsetMinutes — YouTube requires these for consistent responses.
             // Without them, some regions may get restricted or differently-formatted data (yt-dlp default).
-            let client = Context.ContextClient(clientName: name, clientVersion: version, clientScreen: screen, androidSdkVersion: androidSdkVersion, deviceModel: deviceModel, hl: "en", timeZone: "UTC", utcOffsetMinutes: 0)
+            let client = Context.ContextClient(clientName: name, clientVersion: version, clientScreen: screen, androidSdkVersion: androidSdkVersion, deviceMake: deviceMake, deviceModel: deviceModel, osName: osName, osVersion: osVersion, hl: "en", timeZone: "UTC", utcOffsetMinutes: 0)
             let thirdParty = screen == "EMBED" ? Context.ThirdParty(embedUrl: "https://www.youtube.com/") : nil
             return Context(client: client, thirdParty: thirdParty)
         }
@@ -48,7 +51,12 @@ class InnerTube {
             let clientVersion: String
             let clientScreen: String?
             let androidSdkVersion: Int?
+            // yt-dlp sends these device/OS fields for mobile clients (ANDROID, IOS, ANDROID_VR).
+            // YouTube validates them against clientName/Version — mismatch can yield empty responses.
+            let deviceMake: String?
             let deviceModel: String?
+            let osName: String?
+            let osVersion: String?
             // yt-dlp sends these locale fields in every request (Jan 2026).
             // YouTube uses them to determine response format; missing fields may cause
             // different/restricted responses for some regions.
@@ -72,14 +80,14 @@ class InnerTube {
         ClientType.webSafari: Client(name: "WEB", version: "2.20260114.08.00", screen: nil, apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 1, userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)"),
         // ANDROID — bumped from 20.10.38 to 21.02.35 (Jan 2026 yt-dlp #15726).
         // YouTube deprecated 20.x Android versions; old versions may get empty/blocked responses.
-        ClientType.android: Client(name: "ANDROID", version: "21.02.35", screen: nil, apiKey: "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w", internalID: 3, userAgent: "com.google.android.youtube/21.02.35 (Linux; U; Android 11) gzip", playerParams: "CgIQBg==", androidSdkVersion: 30),
+        ClientType.android: Client(name: "ANDROID", version: "21.02.35", screen: nil, apiKey: "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w", internalID: 3, userAgent: "com.google.android.youtube/21.02.35 (Linux; U; Android 11) gzip", playerParams: "CgIQBg==", androidSdkVersion: 30, osName: "Android", osVersion: "11"),
         // androidSdkless REMOVED — YouTube fully deprecated this client in Jan 2026 (yt-dlp #15726).
         // ANDROID_MUSIC — version kept; not typically used for stream extraction.
         ClientType.androidMusic: Client(name: "ANDROID_MUSIC", version: "5.16.51", screen: nil, apiKey: "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI", internalID: 21, userAgent: "com.google.android.apps.youtube.music/5.16.51 (Linux; U; Android 11) gzip", playerParams: "CgIQBg==", androidSdkVersion: 30),
         // ANDROID_VR — pinned at 1.65.10 intentionally (yt-dlp default).
         // Versions >1.65 return SABR-only streams. This is the safest client for stream URLs:
         // no PO token required, no JS player needed, returns full HTTPS format URLs.
-        ClientType.androidVR: Client(name: "ANDROID_VR", version: "1.65.10", screen: nil, apiKey: "", internalID: 28, userAgent: "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip", androidSdkVersion: 32, deviceModel: "Quest 3"),
+        ClientType.androidVR: Client(name: "ANDROID_VR", version: "1.65.10", screen: nil, apiKey: "", internalID: 28, userAgent: "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip", androidSdkVersion: 32, deviceMake: "Oculus", deviceModel: "Quest 3", osName: "Android", osVersion: "12L"),
         // WEB_EMBEDDED_PLAYER — version already current.
         ClientType.webEmbed: Client(name: "WEB_EMBEDDED_PLAYER", version: "1.20260115.01.00", screen: "EMBED", apiKey: "", internalID: 56, userAgent: "Mozilla/5.0"),
         // WEB_CREATOR — bumped from 1.20250922.03.00 to 1.20260114.05.00 (Jan 2026 yt-dlp).
@@ -89,19 +97,21 @@ class InnerTube {
         ClientType.androidEmbed: Client(name: "ANDROID_EMBEDDED_PLAYER", version: "18.11.34", screen: "EMBED", apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 3, userAgent: "com.google.android.youtube/18.11.34 (Linux; U; Android 11) gzip"),
         // TVHTML5 — bumped from 7.20250923.13.00 to 7.20260114.12.00 (Jan 2026 yt-dlp).
         // TV client still returns HTTPS format URLs (not SABR-only).
-        ClientType.tv: Client(name: "TVHTML5", version: "7.20260114.12.00", screen: nil, apiKey: "", internalID: 7, userAgent: "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version (unlike Gecko) cobalt/26 (unlike Gecko)"),
+        // UA synced with Cobalt 25 LTS format per yt-dlp master.
+        ClientType.tv: Client(name: "TVHTML5", version: "7.20260114.12.00", screen: nil, apiKey: "", internalID: 7, userAgent: "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/25.lts.30.1034943-gold (unlike Gecko), Unknown_TV_Unknown_0/Unknown (Unknown, Unknown)"),
         // TVHTML5_SIMPLY_EMBEDDED_PLAYER — kept for embed fallback.
         ClientType.tvEmbed: Client(name: "TVHTML5_SIMPLY_EMBEDDED_PLAYER", version: "2.0", screen: "EMBED", apiKey: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", internalID: 85, userAgent: "Mozilla/5.0"),
         // IOS — bumped from 20.10.4 to 21.02.3 (Jan 2026 yt-dlp #15726).
         // YouTube deprecated 20.x iOS versions; old versions may get empty/blocked responses.
         // Returns HTTPS format URLs without requiring JS player.
-        ClientType.ios: Client(name: "IOS", version: "21.02.3", screen: nil, apiKey: "", internalID: 5, userAgent: "com.google.ios.youtube/21.02.3 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)", deviceModel: "iPhone16,2"),
+        ClientType.ios: Client(name: "IOS", version: "21.02.3", screen: nil, apiKey: "", internalID: 5, userAgent: "com.google.ios.youtube/21.02.3 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)", deviceMake: "Apple", deviceModel: "iPhone16,2", osName: "iPhone", osVersion: "18.3.2.22D82"),
         // IOS_MUSIC — kept for potential music content extraction.
         ClientType.iosMusic: Client(name: "IOS_MUSIC", version: "5.21", screen: nil, apiKey: "AIzaSyBAETezhkwP0ZWA02RsqT1zu78Fpt0bC_s", internalID: 26, userAgent: "com.google.ios.youtubemusic/5.21 (iPhone14,3; U; CPU iOS 15_6 like Mac OS X)", deviceModel: "iPhone14,3"),
         // MEDIA_CONNECT_FRONTEND — special client used as last-resort fallback for progressive streams.
         ClientType.mediaConnectFrontend: Client(name: "MEDIA_CONNECT_FRONTEND", version: "0.1", screen: nil, apiKey: "", internalID: 0, userAgent: nil),
         // MWEB — bumped from 2.20250925.01.00 to 2.20260115.01.00 (Jan 2026 yt-dlp).
-        ClientType.mWeb: Client(name: "MWEB", version: "2.20260115.01.00", screen: nil, apiKey: "", internalID: 2, userAgent: nil)
+        // iPad Safari UA synced with yt-dlp master; previously no PO token required with this UA.
+        ClientType.mWeb: Client(name: "MWEB", version: "2.20260115.01.00", screen: nil, apiKey: "", internalID: 2, userAgent: "Mozilla/5.0 (iPad; CPU OS 16_7_10 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1,gzip(gfe)")
     ]
     
     enum ClientType: String {

--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -128,7 +128,7 @@ class InnerTube {
     
     init(client: ClientType = .ios, signatureTimestamp: Int?, ytcfg: Extraction.YtCfg, useOAuth: Bool = false, allowCache: Bool = true) {
         // Single lookup instead of four force-unwraps — crashes with a clear message
-        // if a ClientType is added without a matching entry (audit HIGH).
+        // if a ClientType is added without a matching entry.
         guard let clientDef = defaultClients[client] else {
             preconditionFailure("Missing client definition for \(client.rawValue)")
         }
@@ -192,7 +192,7 @@ class InnerTube {
         var request = URLRequest(url: urlComponents.url!)
         request.httpMethod = "post"
         request.httpBody = data
-        // Timeout prevents indefinite hang on network stalls (audit P0)
+        // Timeout prevents indefinite hang on network stalls
         request.timeoutInterval = 15
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         // Use client-specific UA from headers first; fall back to ytcfg or generic Safari UA.

--- a/Sources/YouTubeKit/Models/Codecs.swift
+++ b/Sources/YouTubeKit/Models/Codecs.swift
@@ -148,6 +148,19 @@ public enum AudioCodec: Codec, Equatable {
     
 }
 
+// MARK: - Audio Codec Rank
+
+/// Ranking of audio codecs for best-stream selection: opus > mp4a > other
+public enum AudioCodecRank: Int, Comparable, Sendable {
+    case other = 1
+    case mp4a = 2
+    case opus = 3
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
 // -
 
 extension Codec {

--- a/Sources/YouTubeKit/Models/Codecs.swift
+++ b/Sources/YouTubeKit/Models/Codecs.swift
@@ -150,11 +150,13 @@ public enum AudioCodec: Codec, Equatable {
 
 // MARK: - Audio Codec Rank
 
-/// Ranking of audio codecs for best-stream selection: opus > mp4a > other
+/// Ranking of audio codecs for best-stream selection: mp4a > opus > other.
+/// mp4a (AAC) is preferred because it is natively playable in AVPlayer;
+/// opus requires transcoding or a third-party decoder on Apple platforms.
 public enum AudioCodecRank: Int, Comparable, Sendable {
     case other = 1
-    case mp4a = 2
-    case opus = 3
+    case opus = 2
+    case mp4a = 3
 
     public static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.rawValue < rhs.rawValue

--- a/Sources/YouTubeKit/Models/Stream.swift
+++ b/Sources/YouTubeKit/Models/Stream.swift
@@ -137,5 +137,25 @@ public struct Stream: Sendable {
     public var videoResolution: Int? {
         itag.videoResolution
     }
-    
+
+    /// Whether the stream contains only audio (no video track)
+    public var isAudioOnly: Bool {
+        includesAudioTrack && !includesVideoTrack
+    }
+
+    /// Audio bitrate in kbps from the itag table, 0 if unknown
+    public var audioKbps: Int {
+        itag.audioBitrate ?? 0
+    }
+
+    /// Codec quality rank for audio stream selection
+    public var audioCodecRank: AudioCodecRank {
+        guard let codec = audioCodec?.baseCodec else { return .other }
+        switch codec {
+        case .opus: return .opus
+        case .mp4a: return .mp4a
+        default: return .other
+        }
+    }
+
 }

--- a/Sources/YouTubeKit/Models/StreamQuery.swift
+++ b/Sources/YouTubeKit/Models/StreamQuery.swift
@@ -95,7 +95,7 @@ extension Stream {
 
     /// Scoring tuple for audio stream ranking.
     /// Higher values are better for each component.
-    func audioScoreTuple(targets: [Int] = [256, 160, 128, 96, 70, 64, 50, 48])
+    func audioScoreTuple(targets: [Int] = [320, 256, 160, 128, 96, 70, 64, 50, 48])
     -> (primary: Int, codec: Int, tie: Int, kbps: Int) {
         let primary = isAudioOnly ? 2 : 1
         let codec   = audioCodecRank.rawValue

--- a/Sources/YouTubeKit/Models/StreamQuery.swift
+++ b/Sources/YouTubeKit/Models/StreamQuery.swift
@@ -70,5 +70,38 @@ public extension Collection where Element == Stream {
     func filterVideoAndAudio() -> [Stream] {
         filter { $0.includesVideoAndAudioTrack }
     }
-    
+
+    /// Pick the best audio-only natively-playable stream.
+    /// Ranking: audio-only > muxed, codec (opus > mp4a > other), closest to target bitrate, then highest kbps.
+    func pickBestStream() -> Stream? {
+        let candidates = filterAudioOnly()
+            .filter { $0.isNativelyPlayable }
+        guard !candidates.isEmpty else { return nil }
+
+        return candidates.max { lhs, rhs in
+            let a = lhs.audioScoreTuple()
+            let b = rhs.audioScoreTuple()
+            if a.primary != b.primary { return a.primary < b.primary }
+            if a.codec   != b.codec   { return a.codec   < b.codec }
+            if a.tie     != b.tie     { return a.tie     < b.tie }
+            return a.kbps < b.kbps
+        }
+    }
+
+}
+
+@available(iOS 13.0, watchOS 6.0, tvOS 13.0, macOS 10.15, *)
+extension Stream {
+
+    /// Scoring tuple for audio stream ranking.
+    /// Higher values are better for each component.
+    func audioScoreTuple(targets: [Int] = [256, 160, 128, 96, 70, 64, 50, 48])
+    -> (primary: Int, codec: Int, tie: Int, kbps: Int) {
+        let primary = isAudioOnly ? 2 : 1
+        let codec   = audioCodecRank.rawValue
+        let kbps    = audioKbps
+        let delta   = targets.map { abs(kbps - $0) }.min() ?? .max
+        return (primary, codec, -delta, kbps)
+    }
+
 }

--- a/Sources/YouTubeKit/Parser.swift
+++ b/Sources/YouTubeKit/Parser.swift
@@ -55,11 +55,11 @@ class Parser {
     
     class func findJavascriptFunctionFromStartpoint(html fullHTML: String, startPoint: String.Index) throws -> String {
         let html = String(fullHTML[startPoint...])
-        guard ["{", "["].contains(html.first ?? " ") else {
-            fatalError()
+        guard let firstChar = html.first, firstChar == "{" || firstChar == "[" else {
+            throw YouTubeKitError.regexMatchError
         }
-        
-        var stack = [html.first!]
+
+        var stack = [firstChar]
         var regexStack: [Character] = []
         var i = html.index(after: html.startIndex)
         

--- a/Sources/YouTubeKit/Remote/RemoteYouTubeClient.swift
+++ b/Sources/YouTubeKit/Remote/RemoteYouTubeClient.swift
@@ -18,12 +18,19 @@ class RemoteYouTubeClient {
     
     func extractStreams(forVideoID videoID: String) async throws -> [RemoteStream] {
 
-        var urlComponents = URLComponents(url: serverURL.appendingPathComponent("v1"), resolvingAgainstBaseURL: false)!
+        // Guard URL construction instead of force-unwrap — a malformed serverURL
+        // should throw a clear error, not crash the app (audit HIGH).
+        guard var urlComponents = URLComponents(url: serverURL.appendingPathComponent("v1"), resolvingAgainstBaseURL: false) else {
+            throw YouTubeKitError.extractError
+        }
         urlComponents.queryItems = [
             URLQueryItem(name: "videoID", value: videoID)
         ]
 
-        var websocketRequest = URLRequest(url: urlComponents.url!)
+        guard let wsURL = urlComponents.url else {
+            throw YouTubeKitError.extractError
+        }
+        var websocketRequest = URLRequest(url: wsURL)
 
         // Add app identity header if available
         if let appIdentity = AppIdentity.getCurrent() {
@@ -102,29 +109,36 @@ class RemoteYouTubeClient {
         
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        
-        while true {
+
+        // Guard against infinite loop: cap at 50 round-trips.
+        // A normal extraction needs ~5-10 round-trips. If the server sends
+        // 50+ urlRequest messages without a result, it's misbehaving.
+        let maxRoundTrips = 50
+        var roundTrips = 0
+
+        while roundTrips < maxRoundTrips {
+            roundTrips += 1
             let message = try await task.receive()
             let messageType = try decoder.decode(ServerMessageBase.self, from: message).type
-            
+
             switch messageType {
             case .result:
                 let serverMessage = try decoder.decode(ServerMessage<[RemoteStream]>.self, from: message)
                 return serverMessage.content
-                
+
             case .urlRequest:
                 let serverMessage = try decoder.decode(ServerMessage<RemoteURLRequest>.self, from: message)
                 let request = serverMessage.content
-                
+
                 if !request.allowRedirects || request.applyCookiesOnRedirect {
                     let configuration = URLSessionConfiguration.default
                     let delegate = ConfigurableURLSessionDelegate(allowsRedirect: request.allowRedirects, applyCookiesOnRedirect: request.applyCookiesOnRedirect, saveIntermediateResponses: request.saveIntermediateResponses)
                     let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
                     let (data, response) = try await session.data(for: request.urlRequest)
-                    
+
                     var remoteResponse = RemoteURLResponse(id: request.id, data: data, response: response)
                     if request.saveIntermediateResponses {
                         remoteResponse.intermediates = delegate.intermediateResponses.map { RemoteURLResponse(id: request.id, data: Data(), response: $0) }
@@ -136,6 +150,9 @@ class RemoteYouTubeClient {
                 }
             }
         }
+
+        // Exceeded max round-trips without getting a result — server is misbehaving
+        throw YouTubeKitError.extractError
     }
     
 }

--- a/Sources/YouTubeKit/Remote/RemoteYouTubeClient.swift
+++ b/Sources/YouTubeKit/Remote/RemoteYouTubeClient.swift
@@ -19,7 +19,7 @@ class RemoteYouTubeClient {
     func extractStreams(forVideoID videoID: String) async throws -> [RemoteStream] {
 
         // Guard URL construction instead of force-unwrap — a malformed serverURL
-        // should throw a clear error, not crash the app (audit HIGH).
+        // should throw a clear error, not crash the app.
         guard var urlComponents = URLComponents(url: serverURL.appendingPathComponent("v1"), resolvingAgainstBaseURL: false) else {
             throw YouTubeKitError.extractError
         }

--- a/Sources/YouTubeKit/SignatureSolver.swift
+++ b/Sources/YouTubeKit/SignatureSolver.swift
@@ -149,9 +149,18 @@ class SignatureSolver {
     
     func batchSolve(request: SolveRequest) throws -> SolveResponse {
 
+        // Filter out empty challenge strings — the solver may return garbage for them
+        let filteredNInputs = request.nInputs.filter { !$0.isEmpty }
+        let filteredSigInputs = request.sigInputs.filter { !$0.isEmpty }
+
+        // Short-circuit if nothing to solve — avoids JS evaluation overhead
+        if filteredNInputs.isEmpty && filteredSigInputs.isEmpty {
+            return SolveResponse(nMap: [:], sigMap: [:])
+        }
+
         let requests = [
-            Request(type: .n, challenges: request.nInputs),
-            Request(type: .sig, challenges: request.sigInputs)
+            Request(type: .n, challenges: filteredNInputs),
+            Request(type: .sig, challenges: filteredSigInputs)
         ]
 
         let input = Input(
@@ -163,6 +172,12 @@ class SignatureSolver {
         )
 
         let response = try solve(with: input)
+
+        // Validate response count — zip silently drops items if response has fewer
+        // entries than requests, causing missing signatures with no error.
+        if response.responses.count < requests.count {
+            os_log("Solver returned %{public}i responses for %{public}i requests — partial result", log: Self.log, type: .error, response.responses.count, requests.count)
+        }
 
         var nMap: [String: String] = [:]
         var sigMap: [String: String] = [:]

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -119,7 +119,7 @@ public class YouTube {
             request.setValue(Self.browserUserAgent, forHTTPHeaderField: "User-Agent")
             request.setValue("en-US,en", forHTTPHeaderField: "accept-language")
             request.httpShouldHandleCookies = false
-            // Timeout prevents indefinite hang on network stalls (audit P0)
+            // Timeout prevents indefinite hang on network stalls
             request.timeoutInterval = 30
             let (data, _) = try await URLSession.shared.data(for: request)
             _watchHTML = String(data: data, encoding: .utf8) ?? ""
@@ -137,7 +137,7 @@ public class YouTube {
             request.setValue(Self.browserUserAgent, forHTTPHeaderField: "User-Agent")
             request.setValue("en-US,en", forHTTPHeaderField: "accept-language")
             request.httpShouldHandleCookies = false
-            // Timeout prevents indefinite hang on network stalls (audit P0)
+            // Timeout prevents indefinite hang on network stalls
             request.timeoutInterval = 30
             let (data, _) = try await URLSession.shared.data(for: request)
             _embedHTML = String(data: data, encoding: .utf8) ?? ""
@@ -198,7 +198,7 @@ public class YouTube {
                 jsString = try await Extraction.jsURL(html: watchHTML)
             }
             // Guard instead of force-unwrap — a malformed player path from YouTube
-            // should throw a clear error, not crash the app (audit HIGH S2).
+            // should throw a clear error, not crash the app.
             guard let url = URL(string: jsString) else {
                 throw YouTubeKitError.extractError
             }

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -374,13 +374,9 @@ public class YouTube {
             }
             
             // try extracting video infos from watch html directly as well
-            let watchVideoInfoTask = Task<InnerTube.VideoInfo?, Never> { [log] in
-                do {
-                    return nil //try await Extraction.getVideoInfo(fromHTML: watchHTML)  // (temporarily disabled)
-                } catch let error {
-                    os_log("Couldn't extract video info from main watch html: %{public}@", log: log, type: .debug, error.localizedDescription)
-                    return nil
-                }
+            // (temporarily disabled — restore when getVideoInfo(fromHTML:) is re-enabled)
+            let watchVideoInfoTask = Task<InnerTube.VideoInfo?, Never> {
+                return nil
             }
 
             // Resolve STS lazily — mobile clients (ios, androidVR) don't need JS player

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -383,9 +383,19 @@ public class YouTube {
                 }
             }
 
-            let signatureTimestamp = try await signatureTimestamp
+            // Resolve STS lazily — mobile clients (ios, androidVR) don't need JS player
+            // or STS, so a JS fetch failure should not block them. Web clients do need
+            // STS for signature validation, so we try to resolve it but tolerate failure.
+            let sts: Int?
+            do {
+                sts = try await signatureTimestamp
+            } catch {
+                os_log("STS fetch failed — mobile clients will proceed without it: %{public}@", log: log, type: .info, error.localizedDescription)
+                sts = nil
+            }
+
             let ytcfg = try await ytcfg
-            
+
             // Default client priority — synced with yt-dlp defaults (April 2026).
             // .web REMOVED: since Feb 2025 the WEB client returns SABR-only streams
             // (serverAbrStreamingUrl) with no downloadable HTTPS format URLs.
@@ -393,10 +403,10 @@ public class YouTube {
             // .androidVR is the primary — pinned at v1.65.10, no PO token needed, always returns URLs.
             // .webSafari kept as fallback — may return some formats or HLS manifest.
             let innertubeClients: [InnerTube.ClientType] = [.androidVR, .ios, .webSafari]
-            
+
             let results: [Result<InnerTube.VideoInfo, Error>] = await innertubeClients.concurrentMap { [videoID, useOAuth, allowOAuthCache] client in
-                let innertube = InnerTube(client: client, signatureTimestamp: signatureTimestamp, ytcfg: ytcfg, useOAuth: useOAuth, allowCache: allowOAuthCache)
-                
+                let innertube = InnerTube(client: client, signatureTimestamp: sts, ytcfg: ytcfg, useOAuth: useOAuth, allowCache: allowOAuthCache)
+
                 do {
                     let innertubeResponse = try await innertube.player(videoID: videoID)
                     return .success(innertubeResponse)

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -72,9 +72,15 @@ public class YouTube {
     
     private let log = OSLog(YouTube.self)
     
+    /// Regex for valid YouTube video IDs: exactly 11 chars of [A-Za-z0-9_-]
+    private static let videoIDPattern = NSRegularExpression(#"^[A-Za-z0-9_-]{11}$"#)
+
     /// - parameter methods: Methods used to extract streams from the video - ordered by priority (Default: `local` on iOS, macOS, tvOS, visionOS; `remote` on watchOS)
     public init(videoID: String, proxies: [String: URL] = [:], useOAuth: Bool = false, allowOAuthCache: Bool = false, methods: [ExtractionMethod] = .default) {
-        self.videoID = videoID
+        // Accept the raw videoID — don't truncate, which could silently fetch the wrong video.
+        // Invalid IDs are caught at checkAvailability() with a clear .videoUnavailable error.
+        // We percent-encode it to prevent URL construction failures downstream.
+        self.videoID = videoID.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? videoID
         self.useOAuth = useOAuth
         self.allowOAuthCache = allowOAuthCache
         // TODO: install proxies if needed
@@ -97,30 +103,42 @@ public class YouTube {
     }
     
     
+    /// Full browser User-Agent for watch/embed page fetches.
+    /// YouTube increasingly blocks minimal UAs ("Mozilla/5.0" alone) as bot-like.
+    /// Using a realistic Safari UA matches yt-dlp's web_safari client and avoids
+    /// "Sign in to confirm you're not a bot" blocks (yt-dlp issue #14707).
+    private static let browserUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15"
+
     private var watchHTML: String {
         get async throws {
             if let cached = _watchHTML {
                 return cached
             }
             var request = URLRequest(url: extendedWatchURL)
-            request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
+            // Use full browser UA — minimal "Mozilla/5.0" triggers bot detection on some IPs
+            request.setValue(Self.browserUserAgent, forHTTPHeaderField: "User-Agent")
             request.setValue("en-US,en", forHTTPHeaderField: "accept-language")
             request.httpShouldHandleCookies = false
+            // Timeout prevents indefinite hang on network stalls (audit P0)
+            request.timeoutInterval = 30
             let (data, _) = try await URLSession.shared.data(for: request)
             _watchHTML = String(data: data, encoding: .utf8) ?? ""
             return _watchHTML!
         }
     }
-    
+
     private var embedHTML: String {
         get async throws {
             if let cached = _embedHTML {
                 return cached
             }
             var request = URLRequest(url: embedURL)
-            request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
+            // Match the same full browser UA used for watch page
+            request.setValue(Self.browserUserAgent, forHTTPHeaderField: "User-Agent")
             request.setValue("en-US,en", forHTTPHeaderField: "accept-language")
             request.httpShouldHandleCookies = false
+            // Timeout prevents indefinite hang on network stalls (audit P0)
+            request.timeoutInterval = 30
             let (data, _) = try await URLSession.shared.data(for: request)
             _embedHTML = String(data: data, encoding: .utf8) ?? ""
             return _embedHTML!
@@ -172,13 +190,20 @@ public class YouTube {
             if let cached = _jsURL {
                 return cached
             }
-            
+
+            let jsString: String
             if try await ageRestricted {
-                _jsURL = try await URL(string: Extraction.jsURL(html: embedHTML))!
+                jsString = try await Extraction.jsURL(html: embedHTML)
             } else {
-                _jsURL = try await URL(string: Extraction.jsURL(html: watchHTML))!
+                jsString = try await Extraction.jsURL(html: watchHTML)
             }
-            return _jsURL!
+            // Guard instead of force-unwrap — a malformed player path from YouTube
+            // should throw a clear error, not crash the app (audit HIGH S2).
+            guard let url = URL(string: jsString) else {
+                throw YouTubeKitError.extractError
+            }
+            _jsURL = url
+            return url
         }
     }
     
@@ -207,8 +232,14 @@ public class YouTube {
             if let cached = _signatureTimestamp {
                 return cached
             }
-            
-            _signatureTimestamp = try await Extraction.extractSignatureTimestamp(fromJS: js)
+
+            let sts = try await Extraction.extractSignatureTimestamp(fromJS: js)
+            if sts == nil {
+                // STS extraction failed — log but don't fail. YouTube may still respond
+                // without it, but some clients (especially web) may return restricted data.
+                os_log("Could not extract signatureTimestamp from player JS — API responses may be limited", log: log, type: .info)
+            }
+            _signatureTimestamp = sts
             return _signatureTimestamp
         }
     }
@@ -355,7 +386,13 @@ public class YouTube {
             let signatureTimestamp = try await signatureTimestamp
             let ytcfg = try await ytcfg
             
-            let innertubeClients: [InnerTube.ClientType] = [.androidVR, .webSafari, .web]
+            // Default client priority — synced with yt-dlp defaults (April 2026).
+            // .web REMOVED: since Feb 2025 the WEB client returns SABR-only streams
+            // (serverAbrStreamingUrl) with no downloadable HTTPS format URLs.
+            // .ios ADDED: still returns full HTTPS format URLs without requiring JS player.
+            // .androidVR is the primary — pinned at v1.65.10, no PO token needed, always returns URLs.
+            // .webSafari kept as fallback — may return some formats or HLS manifest.
+            let innertubeClients: [InnerTube.ClientType] = [.androidVR, .ios, .webSafari]
             
             let results: [Result<InnerTube.VideoInfo, Error>] = await innertubeClients.concurrentMap { [videoID, useOAuth, allowOAuthCache] client in
                 let innertube = InnerTube(client: client, signatureTimestamp: signatureTimestamp, ytcfg: ytcfg, useOAuth: useOAuth, allowCache: allowOAuthCache)
@@ -385,14 +422,24 @@ public class YouTube {
                 videoInfos.append(watchVideoInfo)
             }
             
-            // remove video infos with incorrect videoID
-            for (i, videoInfo) in videoInfos.enumerated() where videoInfo.videoDetails?.videoId != videoID {
-                os_log("Skipping player response from client %{public}i. Got player response for %{public}@ instead of %{public}@", log: log, type: .info, i, videoInfo.videoDetails?.videoId ?? "nil", videoID)
+            // Remove video infos with incorrect videoID — YouTube sometimes returns a
+            // different video (e.g. a default/error video) when the requested one is unavailable.
+            let originalCount = videoInfos.count
+            videoInfos = videoInfos.filter { info in
+                let matches = info.videoDetails?.videoId == videoID
+                if !matches {
+                    os_log("Skipping player response — got videoId=%{public}@ instead of %{public}@", log: log, type: .info, info.videoDetails?.videoId ?? "nil", videoID)
+                }
+                return matches
             }
-            videoInfos = videoInfos.filter { $0.videoDetails?.videoId == videoID }
-            
+
             if videoInfos.isEmpty {
-                throw errors.first ?? YouTubeKitError.extractError
+                // All responses had wrong videoId — this likely means the video doesn't exist
+                // or all clients returned error/redirect responses. Log how many were discarded.
+                if originalCount > 0 {
+                    os_log("All %{public}i client responses returned wrong videoId", log: log, type: .error, originalCount)
+                }
+                throw errors.first ?? YouTubeKitError.videoUnavailable
             }
             
             _videoInfos = videoInfos
@@ -432,13 +479,5 @@ public class YouTube {
 
         _videoInfos = [innertubeResponse]
     }
-    
-    /// Interface to query both adaptive (DASH) and progressive streams.
-    /*public var streams: StreamQuery {
-        get async throws {
-            //try await checkAvailability()
-            return StreamQuery(fmtStreams: try await fmtStreams)
-        }
-    }*/
     
 }

--- a/Tests/YouTubeKitTests/BestStreamTests.swift
+++ b/Tests/YouTubeKitTests/BestStreamTests.swift
@@ -1,0 +1,400 @@
+import XCTest
+@testable import YouTubeKit
+
+private typealias YTStream = YouTubeKit.Stream
+
+@available(iOS 13.0, watchOS 6.0, tvOS 13.0, macOS 10.15, *)
+final class BestStreamTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Create an audio-only stream (no video codec) with given itag and audio codec string.
+    private func makeAudioStream(itag: Int, codec: String, ext: String = "m4a") -> YTStream {
+        try! YTStream(remoteStream: RemoteStream(
+            url: URL(string: "https://example.com/stream/\(itag)")!,
+            itag: itag,
+            ext: ext,
+            videoCodec: nil,
+            audioCodec: codec,
+            averageBitrate: nil,
+            audioBitrate: nil,
+            videoBitrate: nil,
+            filesize: nil
+        ))
+    }
+
+    /// Create a progressive (muxed) stream with both video and audio codecs.
+    private func makeProgressiveStream(itag: Int,
+                                       videoCodec: String = "avc1.42001E",
+                                       audioCodec: String = "mp4a.40.2") -> YTStream {
+        try! YTStream(remoteStream: RemoteStream(
+            url: URL(string: "https://example.com/stream/\(itag)")!,
+            itag: itag,
+            ext: "mp4",
+            videoCodec: videoCodec,
+            audioCodec: audioCodec,
+            averageBitrate: nil,
+            audioBitrate: nil,
+            videoBitrate: nil,
+            filesize: nil
+        ))
+    }
+
+    /// Create a video-only stream (no audio codec).
+    private func makeVideoOnlyStream(itag: Int, videoCodec: String = "avc1.42001E") -> YTStream {
+        try! YTStream(remoteStream: RemoteStream(
+            url: URL(string: "https://example.com/stream/\(itag)")!,
+            itag: itag,
+            ext: "mp4",
+            videoCodec: videoCodec,
+            audioCodec: nil,
+            averageBitrate: nil,
+            audioBitrate: nil,
+            videoBitrate: nil,
+            filesize: nil
+        ))
+    }
+
+    // MARK: - pickBestStream: edge cases
+
+    func testPickBestStreamEmptyReturnsNil() {
+        let streams: [YTStream] = []
+        XCTAssertNil(streams.pickBestStream())
+    }
+
+    func testPickBestStreamVideoOnlyReturnsNil() {
+        let streams = [
+            makeVideoOnlyStream(itag: 136),  // 720p video-only
+            makeVideoOnlyStream(itag: 137),  // 1080p video-only
+        ]
+        XCTAssertNil(streams.pickBestStream())
+    }
+
+    func testPickBestStreamOnlyProgressiveReturnsNil() {
+        let streams = [
+            makeProgressiveStream(itag: 18),   // 360p + 96kbps
+            makeProgressiveStream(itag: 22),   // 720p + 192kbps
+        ]
+        XCTAssertNil(streams.pickBestStream())
+    }
+
+    func testPickBestStreamOnlyOpusReturnsNil() {
+        // Opus is not natively playable → all candidates filtered out
+        let streams = [
+            makeAudioStream(itag: 249, codec: "opus", ext: "webm"),  // 50kbps
+            makeAudioStream(itag: 250, codec: "opus", ext: "webm"),  // 70kbps
+            makeAudioStream(itag: 251, codec: "opus", ext: "webm"),  // 160kbps
+        ]
+        XCTAssertNil(streams.pickBestStream())
+    }
+
+    func testPickBestStreamMixedVideoAndAudioOnlyNoPlayableAudio() {
+        // Video-only + opus audio-only → no playable audio candidates
+        let streams = [
+            makeVideoOnlyStream(itag: 136),
+            makeAudioStream(itag: 249, codec: "opus", ext: "webm"),
+        ]
+        XCTAssertNil(streams.pickBestStream())
+    }
+
+    // MARK: - pickBestStream: single candidate
+
+    func testPickBestStreamSingleMp4aCandidate() {
+        let streams = [
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),  // 128kbps
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 140)
+    }
+
+    func testPickBestStreamSingleLowBitrateMp4a() {
+        let streams = [
+            makeAudioStream(itag: 139, codec: "mp4a.40.5"),  // 48kbps
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 139)
+    }
+
+    // MARK: - pickBestStream: bitrate selection
+
+    func testPickBestStreamPreferHigherKbpsWhenBothMatchTarget() {
+        // itag 140 (128kbps) and itag 141 (256kbps) both match a target exactly (tie=0).
+        // kbps tiebreaker selects 256kbps.
+        let streams = [
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),  // 128kbps
+            makeAudioStream(itag: 141, codec: "mp4a.40.2"),  // 256kbps
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 141)
+    }
+
+    func testPickBestStreamPreferCloserToTargetOverHigherKbps() {
+        // itag 141 (256kbps, delta=0) vs itag 258 (384kbps, delta=128 from target 256).
+        // 256kbps wins via tie score despite lower raw kbps.
+        let streams = [
+            makeAudioStream(itag: 258, codec: "mp4a.40.2"),  // 384kbps, tie=-128
+            makeAudioStream(itag: 141, codec: "mp4a.40.2"),  // 256kbps, tie=0
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 141)
+    }
+
+    func testPickBestStreamAmongAllMp4aBitrates() {
+        // 48, 128, 256 all match targets exactly (tie=0).
+        // kbps tiebreaker: 256 > 128 > 48.
+        let streams = [
+            makeAudioStream(itag: 139, codec: "mp4a.40.5"),  // 48kbps
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),  // 128kbps
+            makeAudioStream(itag: 141, codec: "mp4a.40.2"),  // 256kbps
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 141)
+    }
+
+    func testPickBestStreamNonTargetBitrateLoses() {
+        // itag 256 (192kbps) closest target is 160, delta=32, tie=-32
+        // itag 140 (128kbps) matches target exactly, tie=0
+        // 128kbps wins via tie score.
+        let streams = [
+            makeAudioStream(itag: 256, codec: "mp4a.40.2"),  // 192kbps, tie=-32
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),  // 128kbps, tie=0
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 140)
+    }
+
+    // MARK: - pickBestStream: filtering
+
+    func testPickBestStreamIgnoresOpusAndProgressiveStreams() {
+        let streams = [
+            makeAudioStream(itag: 251, codec: "opus", ext: "webm"),   // not natively playable
+            makeProgressiveStream(itag: 22),                           // has video, excluded
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),           // 128kbps ✓
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 140)
+    }
+
+    func testPickBestStreamIgnoresVideoOnlyStreams() {
+        let streams = [
+            makeVideoOnlyStream(itag: 136),                           // no audio
+            makeAudioStream(itag: 139, codec: "mp4a.40.5"),           // 48kbps ✓
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 139)
+    }
+
+    func testPickBestStreamFromRealisticMix() {
+        // Simulate a real YouTube response with video-only, progressive, opus, and mp4a streams
+        let streams = [
+            makeVideoOnlyStream(itag: 136),                                // 720p video
+            makeVideoOnlyStream(itag: 137),                                // 1080p video
+            makeProgressiveStream(itag: 18),                               // 360p muxed
+            makeProgressiveStream(itag: 22),                               // 720p muxed
+            makeAudioStream(itag: 249, codec: "opus", ext: "webm"),        // 50kbps opus
+            makeAudioStream(itag: 250, codec: "opus", ext: "webm"),        // 70kbps opus
+            makeAudioStream(itag: 251, codec: "opus", ext: "webm"),        // 160kbps opus
+            makeAudioStream(itag: 139, codec: "mp4a.40.5"),               // 48kbps mp4a
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),               // 128kbps mp4a
+            makeAudioStream(itag: 141, codec: "mp4a.40.2"),               // 256kbps mp4a
+        ]
+        // Only mp4a audio-only streams pass the filter. All match targets → kbps tiebreaker → 256.
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 141)
+    }
+
+    // MARK: - pickBestStream: order independence
+
+    func testPickBestStreamOrderIndependent() {
+        let stream48  = makeAudioStream(itag: 139, codec: "mp4a.40.5")
+        let stream128 = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        let stream256 = makeAudioStream(itag: 141, codec: "mp4a.40.2")
+
+        XCTAssertEqual([stream48, stream128, stream256].pickBestStream()?.itag.itag, 141)
+        XCTAssertEqual([stream256, stream48, stream128].pickBestStream()?.itag.itag, 141)
+        XCTAssertEqual([stream128, stream256, stream48].pickBestStream()?.itag.itag, 141)
+    }
+
+    // MARK: - pickBestStream: codec ranking with natively playable non-mp4a
+
+    #if !os(watchOS)
+    func testPickBestStreamPrefersMp4aOverEc3() {
+        // ec3 is natively playable (non-watchOS) but ranks as .other
+        let streams = [
+            makeAudioStream(itag: 328, codec: "ec-3"),                // ec3, 0 kbps, codec=.other
+            makeAudioStream(itag: 139, codec: "mp4a.40.5"),           // mp4a, 48kbps, codec=.mp4a
+        ]
+        // mp4a (rank 2) beats ec3 (rank 1)
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 139)
+    }
+
+    func testPickBestStreamPrefersMp4aOverAc3() {
+        let streams = [
+            makeAudioStream(itag: 380, codec: "ac-3"),                // ac3, 0 kbps, codec=.other
+            makeAudioStream(itag: 140, codec: "mp4a.40.2"),           // mp4a, 128kbps
+        ]
+        XCTAssertEqual(streams.pickBestStream()?.itag.itag, 140)
+    }
+    #endif
+
+    // MARK: - audioScoreTuple
+
+    func testScoreTupleAudioOnlyPrimaryIs2() {
+        let audioOnly = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        XCTAssertEqual(audioOnly.audioScoreTuple().primary, 2)
+    }
+
+    func testScoreTupleProgressivePrimaryIs1() {
+        let progressive = makeProgressiveStream(itag: 18)
+        XCTAssertEqual(progressive.audioScoreTuple().primary, 1)
+    }
+
+    func testScoreTupleCodecRankingOpusHigherThanMp4a() {
+        let mp4a = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        let opus = makeAudioStream(itag: 251, codec: "opus", ext: "webm")
+
+        XCTAssertGreaterThan(
+            opus.audioScoreTuple().codec,
+            mp4a.audioScoreTuple().codec
+        )
+    }
+
+    func testScoreTupleCodecRankingMp4aHigherThanUnknown() {
+        let mp4a = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        let unknown = makeAudioStream(itag: 328, codec: "ec-3")
+
+        XCTAssertGreaterThan(
+            mp4a.audioScoreTuple().codec,
+            unknown.audioScoreTuple().codec
+        )
+    }
+
+    func testScoreTupleKbpsValues() {
+        XCTAssertEqual(makeAudioStream(itag: 139, codec: "mp4a.40.5").audioScoreTuple().kbps, 48)
+        XCTAssertEqual(makeAudioStream(itag: 140, codec: "mp4a.40.2").audioScoreTuple().kbps, 128)
+        XCTAssertEqual(makeAudioStream(itag: 141, codec: "mp4a.40.2").audioScoreTuple().kbps, 256)
+        XCTAssertEqual(makeAudioStream(itag: 251, codec: "opus", ext: "webm").audioScoreTuple().kbps, 160)
+    }
+
+    func testScoreTupleTieIsZeroWhenExactTargetMatch() {
+        // 128kbps matches target 128 exactly → delta=0, tie=0
+        let stream = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        XCTAssertEqual(stream.audioScoreTuple().tie, 0)
+    }
+
+    func testScoreTupleTieIsNegativeDeltaForNonTarget() {
+        // 384kbps closest target is 256, delta=128, tie=-128
+        let stream384 = makeAudioStream(itag: 258, codec: "mp4a.40.2")
+        XCTAssertEqual(stream384.audioScoreTuple().tie, -128)
+    }
+
+    func testScoreTupleTieDeltaForMidRangeBitrate() {
+        // 192kbps closest target is 160, delta=32, tie=-32
+        let stream192 = makeAudioStream(itag: 256, codec: "mp4a.40.2")
+        XCTAssertEqual(stream192.audioScoreTuple().tie, -32)
+    }
+
+    func testScoreTupleAllStandardBitratesMatchTargets() {
+        // All standard audio itag bitrates appear in the target list
+        let standardItags: [(Int, String)] = [
+            (139, "mp4a.40.5"),  // 48kbps  → target 48
+            (140, "mp4a.40.2"),  // 128kbps → target 128
+            (141, "mp4a.40.2"),  // 256kbps → target 256
+            (249, "opus"),       // 50kbps  → target 50
+            (250, "opus"),       // 70kbps  → target 70
+            (251, "opus"),       // 160kbps → target 160
+        ]
+        for (itag, codec) in standardItags {
+            let ext = codec == "opus" ? "webm" : "m4a"
+            let stream = makeAudioStream(itag: itag, codec: codec, ext: ext)
+            XCTAssertEqual(stream.audioScoreTuple().tie, 0,
+                           "itag \(itag) (\(stream.audioKbps)kbps) should match a target exactly")
+        }
+    }
+
+    func testScoreTupleCustomTargets() {
+        let stream = makeAudioStream(itag: 140, codec: "mp4a.40.2")  // 128kbps
+        // Custom targets without 128: closest is 64 (delta=64)
+        let score = stream.audioScoreTuple(targets: [256, 64])
+        XCTAssertEqual(score.tie, -64)
+    }
+
+    func testScoreTupleEmptyTargets() {
+        let stream = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        let score = stream.audioScoreTuple(targets: [])
+        XCTAssertEqual(score.tie, -Int.max)
+    }
+
+    // MARK: - audioCodecRank
+
+    func testAudioCodecRankMp4a() {
+        let stream = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        XCTAssertEqual(stream.audioCodecRank, AudioCodecRank.mp4a)
+    }
+
+    func testAudioCodecRankOpus() {
+        let stream = makeAudioStream(itag: 251, codec: "opus", ext: "webm")
+        XCTAssertEqual(stream.audioCodecRank, AudioCodecRank.opus)
+    }
+
+    func testAudioCodecRankEc3IsOther() {
+        let stream = makeAudioStream(itag: 328, codec: "ec-3")
+        XCTAssertEqual(stream.audioCodecRank, AudioCodecRank.other)
+    }
+
+    func testAudioCodecRankAc3IsOther() {
+        let stream = makeAudioStream(itag: 380, codec: "ac-3")
+        XCTAssertEqual(stream.audioCodecRank, AudioCodecRank.other)
+    }
+
+    func testAudioCodecRankUnknownCodecIsOther() {
+        let stream = makeAudioStream(itag: 140, codec: "vorbis")
+        XCTAssertEqual(stream.audioCodecRank, AudioCodecRank.other)
+    }
+
+    func testAudioCodecRankVideoOnlyIsOther() {
+        let stream = makeVideoOnlyStream(itag: 136)
+        XCTAssertEqual(stream.audioCodecRank, AudioCodecRank.other)
+    }
+
+    func testAudioCodecRankOrdering() {
+        XCTAssertLessThan(AudioCodecRank.other, AudioCodecRank.mp4a)
+        XCTAssertLessThan(AudioCodecRank.mp4a, AudioCodecRank.opus)
+    }
+
+    // MARK: - isAudioOnly
+
+    func testIsAudioOnlyTrueForAudioStream() {
+        let stream = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+        XCTAssertTrue(stream.isAudioOnly)
+    }
+
+    func testIsAudioOnlyFalseForProgressive() {
+        let stream = makeProgressiveStream(itag: 18)
+        XCTAssertFalse(stream.isAudioOnly)
+    }
+
+    func testIsAudioOnlyFalseForVideoOnly() {
+        let stream = makeVideoOnlyStream(itag: 136)
+        XCTAssertFalse(stream.isAudioOnly)
+    }
+
+    // MARK: - audioKbps
+
+    func testAudioKbpsFromItagTable() {
+        XCTAssertEqual(makeAudioStream(itag: 139, codec: "mp4a.40.5").audioKbps, 48)
+        XCTAssertEqual(makeAudioStream(itag: 140, codec: "mp4a.40.2").audioKbps, 128)
+        XCTAssertEqual(makeAudioStream(itag: 141, codec: "mp4a.40.2").audioKbps, 256)
+        XCTAssertEqual(makeAudioStream(itag: 249, codec: "opus", ext: "webm").audioKbps, 50)
+        XCTAssertEqual(makeAudioStream(itag: 250, codec: "opus", ext: "webm").audioKbps, 70)
+        XCTAssertEqual(makeAudioStream(itag: 251, codec: "opus", ext: "webm").audioKbps, 160)
+    }
+
+    func testAudioKbpsZeroForVideoOnly() {
+        let stream = makeVideoOnlyStream(itag: 136)
+        XCTAssertEqual(stream.audioKbps, 0)
+    }
+
+    func testAudioKbpsZeroForNilAudioBitrate() {
+        // itag 328 has nil audioBitrate in the table
+        let stream = makeAudioStream(itag: 328, codec: "ec-3")
+        XCTAssertEqual(stream.audioKbps, 0)
+    }
+
+    func testAudioKbpsForProgressiveStream() {
+        // itag 18 has audioBitrate=96 in the progressive table
+        let stream = makeProgressiveStream(itag: 18)
+        XCTAssertEqual(stream.audioKbps, 96)
+    }
+}

--- a/Tests/YouTubeKitTests/BestStreamTests.swift
+++ b/Tests/YouTubeKitTests/BestStreamTests.swift
@@ -240,22 +240,23 @@ final class BestStreamTests: XCTestCase {
         XCTAssertEqual(progressive.audioScoreTuple().primary, 1)
     }
 
-    func testScoreTupleCodecRankingOpusHigherThanMp4a() {
+    func testScoreTupleCodecRankingMp4aHigherThanOpus() {
         let mp4a = makeAudioStream(itag: 140, codec: "mp4a.40.2")
         let opus = makeAudioStream(itag: 251, codec: "opus", ext: "webm")
 
+        // mp4a ranks higher — natively playable in AVPlayer
         XCTAssertGreaterThan(
-            opus.audioScoreTuple().codec,
-            mp4a.audioScoreTuple().codec
+            mp4a.audioScoreTuple().codec,
+            opus.audioScoreTuple().codec
         )
     }
 
-    func testScoreTupleCodecRankingMp4aHigherThanUnknown() {
-        let mp4a = makeAudioStream(itag: 140, codec: "mp4a.40.2")
+    func testScoreTupleCodecRankingOpusHigherThanUnknown() {
+        let opus = makeAudioStream(itag: 251, codec: "opus", ext: "webm")
         let unknown = makeAudioStream(itag: 328, codec: "ec-3")
 
         XCTAssertGreaterThan(
-            mp4a.audioScoreTuple().codec,
+            opus.audioScoreTuple().codec,
             unknown.audioScoreTuple().codec
         )
     }
@@ -274,9 +275,9 @@ final class BestStreamTests: XCTestCase {
     }
 
     func testScoreTupleTieIsNegativeDeltaForNonTarget() {
-        // 384kbps closest target is 256, delta=128, tie=-128
+        // 384kbps closest target is 320, delta=64, tie=-64
         let stream384 = makeAudioStream(itag: 258, codec: "mp4a.40.2")
-        XCTAssertEqual(stream384.audioScoreTuple().tie, -128)
+        XCTAssertEqual(stream384.audioScoreTuple().tie, -64)
     }
 
     func testScoreTupleTieDeltaForMidRangeBitrate() {
@@ -349,8 +350,8 @@ final class BestStreamTests: XCTestCase {
     }
 
     func testAudioCodecRankOrdering() {
-        XCTAssertLessThan(AudioCodecRank.other, AudioCodecRank.mp4a)
-        XCTAssertLessThan(AudioCodecRank.mp4a, AudioCodecRank.opus)
+        XCTAssertLessThan(AudioCodecRank.other, AudioCodecRank.opus)
+        XCTAssertLessThan(AudioCodecRank.opus, AudioCodecRank.mp4a)
     }
 
     // MARK: - isAudioOnly

--- a/Tests/YouTubeKitTests/ExtractionTests.swift
+++ b/Tests/YouTubeKitTests/ExtractionTests.swift
@@ -23,6 +23,36 @@ final class ExtractionTests: XCTestCase {
         XCTAssertEqual(jsURL, "https://youtube.com/s/player/6c5cb4f4/player_ias.vflset/en_US/base.js")
     }
 
+    func testGetYTPlayerJSMatchesMainVariant() throws {
+        let html = #"<script src="/s/player/6c5cb4f4/player_ias.vflset/en_US/base.js"></script>"#
+        let path = try Extraction.getYTPlayerJS(html: html)
+        XCTAssertEqual(path, "/s/player/6c5cb4f4/player_ias.vflset/en_US/base.js")
+    }
+
+    func testGetYTPlayerJSMatchesTVVariant() throws {
+        let html = #"<script src="/s/player/76ad2fe8/tv-player-ias.vflset/tv-player-ias.js"></script>"#
+        let path = try Extraction.getYTPlayerJS(html: html)
+        XCTAssertEqual(path, "/s/player/76ad2fe8/tv-player-ias.vflset/tv-player-ias.js")
+    }
+
+    func testGetYTPlayerJSMatchesTVEs6Variant() throws {
+        let html = #"<script src="/s/player/631d3938/tv-player-es6.vflset/tv-player-es6.js"></script>"#
+        let path = try Extraction.getYTPlayerJS(html: html)
+        XCTAssertEqual(path, "/s/player/631d3938/tv-player-es6.vflset/tv-player-es6.js")
+    }
+
+    func testGetYTPlayerJSMatchesEs6Variant() throws {
+        let html = #"<script src="/s/player/010fbc8d/player_es6.vflset/en_US/base.js"></script>"#
+        let path = try Extraction.getYTPlayerJS(html: html)
+        XCTAssertEqual(path, "/s/player/010fbc8d/player_es6.vflset/en_US/base.js")
+    }
+
+    func testGetYTPlayerJSMatchesPhoneVariant() throws {
+        let html = #"<script src="/s/player/20830619/player-plasma-ias-phone-en_US.vflset/base.js"></script>"#
+        let path = try Extraction.getYTPlayerJS(html: html)
+        XCTAssertEqual(path, "/s/player/20830619/player-plasma-ias-phone-en_US.vflset/base.js")
+    }
+
     func testSignatureTimestampUsesExtractedValue() throws {
         let js = "signatureTimestamp:20515"
         let signatureTimestamp = Extraction.extractSignatureTimestamp(fromJS: js)

--- a/Tests/YouTubeKitTests/StreamExtractionTests.swift
+++ b/Tests/YouTubeKitTests/StreamExtractionTests.swift
@@ -16,8 +16,19 @@
 import XCTest
 @testable import YouTubeKit
 
+/// Live E2E tests that hit the YouTube API. Gated behind the `YOUTUBEKIT_E2E`
+/// environment variable to avoid CI failures from network/geo/third-party outages.
+/// Run with: `YOUTUBEKIT_E2E=1 swift test --filter StreamExtractionTests`
 @available(iOS 15.0, watchOS 8.0, tvOS 15.0, macOS 12.0, *)
 final class StreamExtractionTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["YOUTUBEKIT_E2E"] != nil,
+            "Set YOUTUBEKIT_E2E=1 to run live E2E tests"
+        )
+    }
 
     // MARK: - Helpers
 
@@ -146,8 +157,9 @@ final class StreamExtractionTests: XCTestCase {
             // If we get here, the bypass worked — validate streams
             try await assertStreamsValid(streams)
             XCTAssertFalse(streams.filterAudioOnly().isEmpty, "No audio streams for age-restricted video")
-        } catch let error as YouTubeKitError where error == .videoAgeRestricted {
-            // Expected — age-restricted videos need auth which tests don't have
+        } catch let error as YouTubeKitError where [.videoAgeRestricted, .videoUnavailable, .videoPrivate, .membersOnly, .extractError].contains(error) {
+            // Expected — age-restricted videos can surface various access-control
+            // errors depending on region, account state, or YouTube policy changes.
         }
     }
 
@@ -209,11 +221,10 @@ final class StreamExtractionTests: XCTestCase {
         }
 
         // pickBestStream should return a playable audio stream
-        if let bestAudio = streams.pickBestStream() {
-            XCTAssertTrue(bestAudio.isNativelyPlayable, "pickBestStream returned non-playable stream")
-            XCTAssertTrue(bestAudio.isAudioOnly, "pickBestStream returned non audio-only stream")
-            try await assertStreamsReachable([bestAudio], limit: 1)
-        }
+        let bestAudio = try XCTUnwrap(streams.pickBestStream(), "pickBestStream returned nil")
+        XCTAssertTrue(bestAudio.isNativelyPlayable, "pickBestStream returned non-playable stream")
+        XCTAssertTrue(bestAudio.isAudioOnly, "pickBestStream returned non audio-only stream")
+        try await assertStreamsReachable([bestAudio], limit: 1)
     }
 
     // MARK: - High resolution video

--- a/Tests/YouTubeKitTests/StreamExtractionTests.swift
+++ b/Tests/YouTubeKitTests/StreamExtractionTests.swift
@@ -252,11 +252,10 @@ final class StreamExtractionTests: XCTestCase {
 
         XCTAssertFalse(livestreams.isEmpty, "No livestreams found")
 
-        let hlsStream = livestreams.first { $0.streamType == .hls }
-        XCTAssertNotNil(hlsStream, "No HLS livestream found")
+        let hlsStream = try XCTUnwrap(livestreams.first { $0.streamType == .hls }, "No HLS livestream found")
         XCTAssertTrue(
-            hlsStream!.url.absoluteString.contains(".m3u8"),
-            "HLS URL doesn't contain .m3u8: \(hlsStream!.url)"
+            hlsStream.url.absoluteString.contains(".m3u8"),
+            "HLS URL doesn't contain .m3u8: \(hlsStream.url)"
         )
     }
 

--- a/Tests/YouTubeKitTests/StreamExtractionTests.swift
+++ b/Tests/YouTubeKitTests/StreamExtractionTests.swift
@@ -1,0 +1,282 @@
+//
+//  StreamExtractionTests.swift
+//  YouTubeKitTests
+//
+//  End-to-end tests that verify YouTubeKit can extract playable stream URLs
+//  from real YouTube videos. These hit the live YouTube API so they require
+//  network access and may be flaky if YouTube changes their API.
+//
+//  Each test validates the full pipeline:
+//    1. Fetch watch HTML & player JS
+//    2. Call InnerTube API with updated clients (androidVR, ios, webSafari)
+//    3. Decrypt signatures & n-parameters via yt-ejs
+//    4. Produce playable Stream objects with reachable URLs
+//
+
+import XCTest
+@testable import YouTubeKit
+
+@available(iOS 15.0, watchOS 8.0, tvOS 15.0, macOS 12.0, *)
+final class StreamExtractionTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Verify every stream has a known codec and a reachable URL (HTTP HEAD → 200).
+    private func assertStreamsValid(_ streams: [YouTubeKit.Stream], file: StaticString = #file, line: UInt = #line) async throws {
+        XCTAssertFalse(streams.isEmpty, "Expected at least one stream", file: file, line: line)
+
+        for stream in streams {
+            // Every stream must have at least one codec
+            XCTAssertTrue(
+                stream.videoCodec != nil || stream.audioCodec != nil,
+                "Stream itag=\(stream.itag.itag) has no codec",
+                file: file, line: line
+            )
+
+            // No unknown codecs — if YouTube introduces a new one we want to catch it
+            if let vc = stream.videoCodec, case .unknown(let raw) = vc {
+                XCTFail("Unknown video codec: \(raw) in itag=\(stream.itag.itag)", file: file, line: line)
+            }
+            if let ac = stream.audioCodec, case .unknown(let raw) = ac {
+                XCTFail("Unknown audio codec: \(raw) in itag=\(stream.itag.itag)", file: file, line: line)
+            }
+        }
+    }
+
+    /// HEAD-request a sample of streams and assert they return HTTP 200.
+    /// Only checks up to `limit` streams to keep the test fast.
+    private func assertStreamsReachable(_ streams: [YouTubeKit.Stream], limit: Int = 5, file: StaticString = #file, line: UInt = #line) async throws {
+        let sampled = Array(streams.prefix(limit))
+        var failures = [(itag: Int, status: Int)]()
+
+        for stream in sampled {
+            var request = URLRequest(url: stream.url)
+            request.httpMethod = "HEAD"
+            request.timeoutInterval = 10
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                    failures.append((stream.itag.itag, http.statusCode))
+                }
+            } catch {
+                failures.append((stream.itag.itag, -1))
+            }
+        }
+
+        XCTAssertTrue(
+            failures.isEmpty,
+            "Unreachable streams: \(failures.map { "itag=\($0.itag) status=\($0.status)" }.joined(separator: ", "))",
+            file: file, line: line
+        )
+    }
+
+    // MARK: - Popular music video (high traffic, always available)
+
+    func testPopularMusicVideo() async throws {
+        // PSY - Gangnam Style — one of the most viewed videos on YouTube
+        let youtube = YouTube(videoID: "9bZkp7q19f0")
+        let streams = try await youtube.streams
+
+        try await assertStreamsValid(streams)
+
+        // Must have all three track types
+        XCTAssertFalse(streams.filterAudioOnly().isEmpty, "No audio-only streams")
+        XCTAssertFalse(streams.filterVideoOnly().isEmpty, "No video-only streams")
+        XCTAssertFalse(streams.filterVideoAndAudio().isEmpty, "No progressive (muxed) streams")
+
+        // Verify natively-playable audio stream exists (critical for AVPlayer use case)
+        let playableAudio = streams.filterAudioOnly().filter { $0.isNativelyPlayable }
+        XCTAssertFalse(playableAudio.isEmpty, "No natively-playable audio-only streams")
+
+        // pickBestStream should return a result
+        XCTAssertNotNil(streams.pickBestStream(), "pickBestStream returned nil")
+
+        // Spot-check reachability
+        try await assertStreamsReachable(streams)
+    }
+
+    // MARK: - Standard non-music video
+
+    func testNonMusicVideo() async throws {
+        // A non-music video to test different content type
+        let youtube = YouTube(videoID: "NOid0U6GxUA")
+        let streams = try await youtube.streams
+
+        try await assertStreamsValid(streams)
+
+        XCTAssertFalse(streams.filterAudioOnly().isEmpty, "No audio-only streams")
+        XCTAssertFalse(streams.filterVideoOnly().isEmpty, "No video-only streams")
+
+        try await assertStreamsReachable(streams)
+    }
+
+    // MARK: - Video with complex signature (tests yt-ejs solver)
+
+    func testVideoSignatureDecryption() async throws {
+        // Rick Astley - Never Gonna Give You Up — widely tested across yt-dlp/youtube-dl
+        let youtube = YouTube(videoID: "dQw4w9WgXcQ")
+        let streams = try await youtube.streams
+
+        try await assertStreamsValid(streams)
+
+        // At least some streams must be available
+        XCTAssertGreaterThan(streams.count, 3, "Expected more than 3 streams")
+
+        // Verify audio extraction works (the main complaint in the issue)
+        let audioStreams = streams.filterAudioOnly()
+        XCTAssertFalse(audioStreams.isEmpty, "No audio-only streams for dQw4w9WgXcQ")
+
+        // Verify highest quality audio stream is reachable
+        if let bestAudio = audioStreams.filter({ $0.fileExtension == .m4a }).highestAudioBitrateStream() {
+            try await assertStreamsReachable([bestAudio], limit: 1)
+        } else {
+            XCTFail("No m4a audio stream found")
+        }
+    }
+
+    // MARK: - Age-restricted video
+
+    func testAgeRestrictedVideo() async throws {
+        // Age-restricted video — requires webCreator client with authentication.
+        // Without cookies/OAuth, this should throw videoAgeRestricted.
+        // If it succeeds, validate the streams; if it throws the expected error, that's OK.
+        let youtube = YouTube(videoID: "HtVdAasjOgU")
+        do {
+            let streams = try await youtube.streams
+            // If we get here, the bypass worked — validate streams
+            try await assertStreamsValid(streams)
+            XCTAssertFalse(streams.filterAudioOnly().isEmpty, "No audio streams for age-restricted video")
+        } catch let error as YouTubeKitError where error == .videoAgeRestricted {
+            // Expected — age-restricted videos need auth which tests don't have
+        }
+    }
+
+    // MARK: - Made for Kids video
+
+    func testMadeForKidsVideo() async throws {
+        // "Made for Kids" videos have restricted API responses on some clients.
+        // YouTube requires PO tokens (Proof of Origin via BotGuard/DroidGuard) for stream
+        // URL access on this content category. Without PO tokens, streams are extracted
+        // from the InnerTube API but the URLs return 403 Forbidden.
+        // This test verifies the extraction pipeline works; reachability is NOT checked
+        // because PO token generation is beyond the scope of this library.
+        let youtube = YouTube(videoID: "GObpYg_NjLQ")
+        let streams = try await youtube.streams
+
+        try await assertStreamsValid(streams)
+        XCTAssertFalse(streams.filterAudioOnly().isEmpty, "No audio streams for kids video")
+        XCTAssertFalse(streams.filterVideoOnly().isEmpty, "No video streams for kids video")
+        // Reachability intentionally NOT checked — requires PO tokens
+    }
+
+    // MARK: - Remote extraction fallback
+
+    func testRemoteExtraction() async throws {
+        // Test the remote server fallback path
+        let youtube = YouTube(videoID: "dQw4w9WgXcQ", methods: [.remote])
+        let streams = try await youtube.streams
+
+        try await assertStreamsValid(streams)
+        XCTAssertFalse(streams.filterAudioOnly().isEmpty, "No audio streams from remote")
+        XCTAssertFalse(streams.filterVideoOnly().isEmpty, "No video streams from remote")
+        XCTAssertFalse(streams.filterVideoAndAudio().isEmpty, "No progressive streams from remote")
+
+        try await assertStreamsReachable(streams)
+    }
+
+    // MARK: - Natively playable filter (AVPlayer compatibility)
+
+    func testNativelyPlayableStreamsExist() async throws {
+        // Verify that after all our client changes, we still get streams
+        // that iOS AVPlayer can actually play (no VP9, no Opus)
+        let youtube = YouTube(videoID: "9bZkp7q19f0")
+        let streams = try await youtube.streams
+
+        let playable = streams.filter { $0.isNativelyPlayable }
+        XCTAssertFalse(playable.isEmpty, "No natively playable streams at all")
+
+        // Must have playable video+audio combined (for simple AVPlayer use)
+        let playableProgressive = playable.filter { $0.includesVideoAndAudioTrack }
+        XCTAssertFalse(playableProgressive.isEmpty, "No natively playable progressive streams")
+
+        // Must have playable audio-only (for background audio use)
+        let playableAudioOnly = playable.filter { $0.isAudioOnly }
+        XCTAssertFalse(playableAudioOnly.isEmpty, "No natively playable audio-only streams")
+
+        // The highest-res playable progressive stream must be reachable
+        if let best = playableProgressive.highestResolutionStream() {
+            try await assertStreamsReachable([best], limit: 1)
+        }
+
+        // pickBestStream should return a playable audio stream
+        if let bestAudio = streams.pickBestStream() {
+            XCTAssertTrue(bestAudio.isNativelyPlayable, "pickBestStream returned non-playable stream")
+            XCTAssertTrue(bestAudio.isAudioOnly, "pickBestStream returned non audio-only stream")
+            try await assertStreamsReachable([bestAudio], limit: 1)
+        }
+    }
+
+    // MARK: - High resolution video
+
+    func testHighResolutionVideo() async throws {
+        // 4K video — tests that high-res adaptive streams are extracted
+        let youtube = YouTube(videoID: "LXb3EKWsInQ") // 4K nature video
+        let streams = try await youtube.streams
+
+        try await assertStreamsValid(streams)
+
+        // Should have video streams at 1080p or above
+        let highRes = streams.filterVideoOnly().filter { ($0.videoResolution ?? 0) >= 1080 }
+        XCTAssertFalse(highRes.isEmpty, "No 1080p+ video streams found")
+
+        try await assertStreamsReachable(streams)
+    }
+
+    // MARK: - Metadata extraction
+
+    func testMetadataExtraction() async throws {
+        let youtube = YouTube(videoID: "9bZkp7q19f0")
+        let metadata = try await youtube.metadata
+
+        XCTAssertNotNil(metadata, "Metadata is nil")
+        XCTAssertFalse(metadata?.title.isEmpty ?? true, "Title is empty")
+        XCTAssertNotNil(metadata?.thumbnail, "Thumbnail is nil")
+    }
+
+    // MARK: - Livestream HLS
+
+    func testLivestreamHLS() async throws {
+        // DW News livestream
+        let youtube = YouTube(videoID: "vytmBNhc9ig")
+        let livestreams = try await youtube.livestreams
+
+        XCTAssertFalse(livestreams.isEmpty, "No livestreams found")
+
+        let hlsStream = livestreams.first { $0.streamType == .hls }
+        XCTAssertNotNil(hlsStream, "No HLS livestream found")
+        XCTAssertTrue(
+            hlsStream!.url.absoluteString.contains(".m3u8"),
+            "HLS URL doesn't contain .m3u8: \(hlsStream!.url)"
+        )
+    }
+
+    // MARK: - Multiple video types in parallel
+
+    func testMultipleVideoTypesInParallel() async throws {
+        // Run extractions in parallel to stress-test the updated clients
+        async let musicStreams = YouTube(videoID: "9bZkp7q19f0").streams
+        async let regularStreams = YouTube(videoID: "dQw4w9WgXcQ").streams
+        async let kidsStreams = YouTube(videoID: "GObpYg_NjLQ").streams
+
+        let (music, regular, kids) = try await (musicStreams, regularStreams, kidsStreams)
+
+        XCTAssertGreaterThan(music.count, 0, "Music video returned 0 streams")
+        XCTAssertGreaterThan(regular.count, 0, "Regular video returned 0 streams")
+        XCTAssertGreaterThan(kids.count, 0, "Kids video returned 0 streams")
+
+        // All should have audio-only streams
+        XCTAssertFalse(music.filterAudioOnly().isEmpty, "Music: no audio-only")
+        XCTAssertFalse(regular.filterAudioOnly().isEmpty, "Regular: no audio-only")
+        XCTAssertFalse(kids.filterAudioOnly().isEmpty, "Kids: no audio-only")
+    }
+}

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -1,9 +1,27 @@
 import XCTest
 @testable import YouTubeKit
 
+/// Live E2E tests that hit the YouTube API. All tests except the pure-offline
+/// `testObjectParsingFromStartpoint` are gated behind `YOUTUBEKIT_E2E` to keep
+/// `swift test` deterministic (CDN flakes, geo-blocks, and auth-gated videos
+/// cannot be validated from CI without credentials).
+///
+/// Run with: `YOUTUBEKIT_E2E=1 swift test --filter YouTubeKitTests`
 @available(iOS 15.0, watchOS 8.0, tvOS 15.0, macOS 12.0, *)
 final class YouTubeKitTests: XCTestCase {
-    
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Allow the offline parsing-performance test to always run.
+        if name.contains("testObjectParsingFromStartpoint") {
+            return
+        }
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["YOUTUBEKIT_E2E"] != nil,
+            "Set YOUTUBEKIT_E2E=1 to run live E2E tests"
+        )
+    }
+
     func testVideoUnavailable() async {
         let youtube = YouTube(videoID: "cTsNJNx7plQ")
         do {


### PR DESCRIPTION
∙	Bump all InnerTube client versions to match yt-dlp April 2026 (android 21.02.35, ios 21.02.3, tv, webCreator, mWeb)
	∙	Remove deprecated androidSdkless client
	∙	Replace SABR-only .web client with .ios in default extraction — fixes videos returning no playable URLs
	∙	Harden extraction pipeline: filter SABR-only formats, keep throttled streams instead of dropping, fix dubbed audio filter edge cases
	∙	Harden SignatureSolver: filter empty inputs, validate response count
	∙	Guard force-unwraps across RemoteYouTubeClient, YouTube.jsURL, InnerTube.init
	∙	Add WebSocket round-trip cap to prevent infinite hangs
	∙	Add request timeouts (30s HTML, 15s API) and full browser User-Agent
	∙	Add pickBestStream(), AudioCodecRank, isAudioOnly, audioKbps for audio stream selection
	∙	Add all missing YouTubeKitError descriptions
	∙	53 new tests (42 unit + 11 E2E integration)