### PR TITLE
Handle missing format quality

### DIFF
--- a/Sources/YouTubeKit/InnerTube.swift
+++ b/Sources/YouTubeKit/InnerTube.swift
@@ -218,7 +218,7 @@ class InnerTube {
             let height: Int?
             let lastModified: String?
             let contentLength: String?
-            let quality: String
+            let quality: String?
             let fps: Int?
             let qualityLabel: String?
             let averageBitrate: Int?

--- a/Tests/YouTubeKitTests/YouTubeKitTests.swift
+++ b/Tests/YouTubeKitTests/YouTubeKitTests.swift
@@ -297,6 +297,18 @@ final class YouTubeKitTests: XCTestCase {
         }
     }
     
+    func testStreamingFormatDecodesWithoutQuality() throws {
+        let json = #"""
+        {
+            "itag": 18,
+            "url": "https://example.com/video.mp4",
+            "mimeType": "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\""
+        }
+        """#
+        let format = try JSONDecoder().decode(InnerTube.StreamingData.Format.self, from: Data(json.utf8))
+        XCTAssertNil(format.quality)
+    }
+    
 
     // MARK: - Performance Measurement
     


### PR DESCRIPTION
Makes InnerTube streaming format quality optional so decoding survives YouTube responses that omit it.

Adds a focused regression test for decoding a streaming format without quality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small decoding-model change with a unit test; `quality` is not referenced elsewhere in the library sources.
> 
> **Overview**
> **InnerTube** streaming `Format` decoding no longer requires a `quality` field, so player responses that omit it still decode instead of failing JSON parsing.
> 
> Adds **`testStreamingFormatDecodesWithoutQuality`** to lock in decoding minimal format JSON without `quality`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae185bc0c93b895dd87b6d963f60062255a28ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->