### PR TITLE
Make URLSession async-compatibility shims cancellation-aware

### DIFF
--- a/Sources/YouTubeKit/Extensions/AsyncCompatibility.swift
+++ b/Sources/YouTubeKit/Extensions/AsyncCompatibility.swift
@@ -7,36 +7,78 @@
 
 import Foundation
 
-/// Backward compatibility of iOS 15 URLSession async function for older versions
+/// Thread-safe holder tying an in-flight `URLSessionTask` to Swift task cancellation.
+/// If the surrounding Swift task is cancelled before the URLSessionTask is registered,
+/// the URLSessionTask is cancelled immediately upon registration.
+private final class URLSessionTaskCancellationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: URLSessionTask?
+    private var isCancelled = false
+
+    func register(_ task: URLSessionTask) {
+        lock.lock()
+        self.task = task
+        let cancelled = isCancelled
+        lock.unlock()
+        if cancelled {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        isCancelled = true
+        let task = self.task
+        lock.unlock()
+        task?.cancel()
+    }
+}
+
+/// Backward compatibility of iOS 15 URLSession async function for older versions.
+/// Cancellation-aware: cancelling the surrounding Swift task cancels the underlying
+/// `URLSessionTask` (the request fails with `URLError.cancelled`) instead of letting
+/// the download run to completion.
 @available(iOS 13.0, watchOS 6.0, tvOS 13.0, macOS 10.15, *)
 extension URLSession {
-    
-    func data(from url: URL) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            dataTask(with: url) { data, response, error in
-                guard let data = data, let response = response else {
-                    let error = error ?? URLError(.unknown)
-                    return continuation.resume(throwing: error)
-                }
-                
-                continuation.resume(returning: (data, response))
-            }
-            .resume()
-        }
-    }
-    
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            dataTask(with: request) { data, response, error in
-                guard let data = data, let response = response else {
-                    let error = error ?? URLError(.unknown)
-                    return continuation.resume(throwing: error)
-                }
 
-                continuation.resume(returning: (data, response))
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        let box = URLSessionTaskCancellationBox()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = dataTask(with: url) { data, response, error in
+                    guard let data = data, let response = response else {
+                        let error = error ?? URLError(.unknown)
+                        return continuation.resume(throwing: error)
+                    }
+
+                    continuation.resume(returning: (data, response))
+                }
+                box.register(task)
+                task.resume()
             }
-            .resume()
+        } onCancel: {
+            box.cancel()
         }
     }
-    
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let box = URLSessionTaskCancellationBox()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = dataTask(with: request) { data, response, error in
+                    guard let data = data, let response = response else {
+                        let error = error ?? URLError(.unknown)
+                        return continuation.resume(throwing: error)
+                    }
+
+                    continuation.resume(returning: (data, response))
+                }
+                box.register(task)
+                task.resume()
+            }
+        } onCancel: {
+            box.cancel()
+        }
+    }
+
 }

--- a/Sources/YouTubeKit/Extensions/AsyncCompatibility.swift
+++ b/Sources/YouTubeKit/Extensions/AsyncCompatibility.swift
@@ -42,30 +42,22 @@ private final class URLSessionTaskCancellationBox: @unchecked Sendable {
 extension URLSession {
 
     func data(from url: URL) async throws -> (Data, URLResponse) {
-        let box = URLSessionTaskCancellationBox()
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                let task = dataTask(with: url) { data, response, error in
-                    guard let data = data, let response = response else {
-                        let error = error ?? URLError(.unknown)
-                        return continuation.resume(throwing: error)
-                    }
-
-                    continuation.resume(returning: (data, response))
-                }
-                box.register(task)
-                task.resume()
-            }
-        } onCancel: {
-            box.cancel()
-        }
+        try await performCancellableDataTask { dataTask(with: url, completionHandler: $0) }
     }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await performCancellableDataTask { dataTask(with: request, completionHandler: $0) }
+    }
+
+    /// Shared body for the async shims: bridge a completion-handler `dataTask` to
+    /// async, cancelling the underlying `URLSessionTask` when the Swift task is cancelled.
+    private func performCancellableDataTask(
+        _ makeTask: (@escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+    ) async throws -> (Data, URLResponse) {
         let box = URLSessionTaskCancellationBox()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                let task = dataTask(with: request) { data, response, error in
+                let task = makeTask { data, response, error in
                     guard let data = data, let response = response else {
                         let error = error ?? URLError(.unknown)
                         return continuation.resume(throwing: error)


### PR DESCRIPTION
### Problem

The `URLSession.data(from:)` / `data(for:)` back-compat shims in `AsyncCompatibility.swift` wrap `dataTask` in a plain `withCheckedThrowingContinuation` with no cancellation handling. When the surrounding `Task` is cancelled, the underlying `URLSessionTask` keeps running and downloads to completion — cancellation is silently ignored.

In an app that starts extractions on scroll/focus changes and cancels superseded ones, this leaves "zombie" downloads competing for bandwidth. On a constrained device link they starved foreground work for 20–40s in our testing (an extraction for a title the user had already scrolled past kept running to completion).

### Fix

Wrap both shims in `withTaskCancellationHandler` and cancel the `URLSessionTask` when the Swift task is cancelled. A small locked box ties the two together and handles the race where cancellation arrives before the `dataTask` is registered (cancel-on-register). Cancelled requests now fail promptly with `URLError(.cancelled)`.

No public API change; behaviour is identical for non-cancelled calls. The `@available` bounds already match the shims' existing platform floor (iOS 13 / tvOS 13 / watchOS 6 / macOS 10.15).

### Verification

Builds clean across the CI matrix locally, including explicit Swift 6 language mode.

<!-- codex-pr-summary:start -->
---

> [!NOTE]
> **Overview**
>
> **Cancellation-aware async shims.** This PR updates YouTubeKit’s backwards-compatible `URLSession` async helpers so cancellation of the surrounding Swift task also cancels the underlying `URLSessionTask`.
>
> **Shared request bridge.** The existing `data(from:)` and `data(for:)` shims now route through `performCancellableDataTask`, keeping the completion-handler-to-async bridging logic in one place while preserving the existing `(Data, URLResponse)` behavior and error handling.
>
> **Thread-safe task tracking.** A private `URLSessionTaskCancellationBox` coordinates task registration and cancellation with `NSLock`, covering the case where cancellation happens before the `URLSessionTask` has been registered.
<!-- codex-pr-summary:end -->
