### PR TITLE
Reuse SignatureSolver across videos (cache per player JS + preprocessed player)

### DIFF
--- a/Sources/YouTubeKit/Extraction.swift
+++ b/Sources/YouTubeKit/Extraction.swift
@@ -394,7 +394,8 @@ class Extraction {
 #if canImport(JavaScriptCore)
     /// apply the decrypted signature to the stream manifest
     class func applySignature(streamManifest: inout [InnerTube.StreamingData.Format], videoInfo: InnerTube.VideoInfo, js: String) throws {
-        let solver = try SignatureSolver(js: js)
+        try Task.checkCancellation()
+        let solver = try SignatureSolver.shared(forJS: js)
 
         var sigInputs: [String] = []
         var nInputs: [String] = []

--- a/Sources/YouTubeKit/SignatureSolver.swift
+++ b/Sources/YouTubeKit/SignatureSolver.swift
@@ -14,6 +14,33 @@ class SignatureSolver {
 
     private static let log = OSLog(SignatureSolver.self)
 
+    // MARK: Shared instance cache
+    // Solver construction (JSContext + meriyah/astring bundle eval) and the first
+    // solve (full player parse) are very expensive on JIT-less platforms (tvOS/iOS
+    // JavaScriptCore runs interpreted). Cache one solver per player-JS version so
+    // subsequent videos reuse the context and the preprocessed player.
+    private static let sharedLock = NSLock()
+    nonisolated(unsafe) private static var sharedSolver: (jsHash: Int, solver: SignatureSolver)?
+
+    static func shared(forJS js: String) throws -> SignatureSolver {
+        let hash = js.hashValue
+        sharedLock.lock()
+        defer { sharedLock.unlock() }
+        if let cached = sharedSolver, cached.jsHash == hash {
+            return cached.solver
+        }
+        let start = Date()
+        let solver = try SignatureSolver(js: js)
+        os_log("solver init took %.2fs", log: log, type: .default, Date().timeIntervalSince(start))
+        sharedSolver = (hash, solver)
+        return solver
+    }
+
+    /// Player preprocessed by the first solve; skips the full player parse afterwards
+    private var preprocessedPlayer: String?
+    /// JSContext isn't thread-safe; the shared instance serializes solves
+    private let solveLock = NSLock()
+
     private let vm = JSVirtualMachine()
     private let ctx: JSContext
     
@@ -148,21 +175,44 @@ class SignatureSolver {
     }
     
     func batchSolve(request: SolveRequest) throws -> SolveResponse {
+        solveLock.lock()
+        defer { solveLock.unlock() }
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
+            try Task.checkCancellation()
+        }
 
         let requests = [
             Request(type: .n, challenges: request.nInputs),
             Request(type: .sig, challenges: request.sigInputs)
         ]
 
-        let input = Input(
-            type: .player,
-            player: self.playerJS,
-            preprocessed_player: nil,
-            requests: requests,
-            output_preprocessed: false
-        )
+        let input: Input
+        if let preprocessedPlayer {
+            input = Input(
+                type: .preprocessedPlayer,
+                player: nil,
+                preprocessed_player: preprocessedPlayer,
+                requests: requests,
+                output_preprocessed: false
+            )
+        } else {
+            input = Input(
+                type: .player,
+                player: self.playerJS,
+                preprocessed_player: nil,
+                requests: requests,
+                output_preprocessed: true
+            )
+        }
 
+        let solveStart = Date()
         let response = try solve(with: input)
+        os_log("batch solve took %.2fs (preprocessed: %{public}@)", log: Self.log, type: .default, Date().timeIntervalSince(solveStart), preprocessedPlayer != nil ? "yes" : "no")
+
+        if preprocessedPlayer == nil {
+            preprocessedPlayer = response.preprocessed_player
+        }
 
         var nMap: [String: String] = [:]
         var sigMap: [String: String] = [:]

--- a/Sources/YouTubeKit/SignatureSolver.swift
+++ b/Sources/YouTubeKit/SignatureSolver.swift
@@ -24,7 +24,11 @@ class SignatureSolver {
     /// Bounded because each solver retains a JSContext and the ~2 MB player;
     /// a session rarely uses more than a couple of player variants (e.g. web
     /// vs TV/embed), so alternating between them still reuses each solver.
+#if swift(>=5.10)
     nonisolated(unsafe) private static var sharedSolvers: [SignatureSolver] = []
+#else
+    private static var sharedSolvers: [SignatureSolver] = []
+#endif
     private static let maxCachedSolvers = 4
 
     static func shared(forJS js: String) throws -> SignatureSolver {

--- a/Sources/YouTubeKit/SignatureSolver.swift
+++ b/Sources/YouTubeKit/SignatureSolver.swift
@@ -20,16 +20,23 @@ class SignatureSolver {
     // JavaScriptCore runs interpreted). Cache one solver per player-JS version so
     // subsequent videos reuse the context and the preprocessed player.
     private static let sharedLock = NSLock()
-    nonisolated(unsafe) private static var sharedSolver: SignatureSolver?
+    /// Small most-recently-used cache of solvers keyed by their player JS.
+    /// Bounded because each solver retains a JSContext and the ~2 MB player;
+    /// a session rarely uses more than a couple of player variants (e.g. web
+    /// vs TV/embed), so alternating between them still reuses each solver.
+    nonisolated(unsafe) private static var sharedSolvers: [SignatureSolver] = []
+    private static let maxCachedSolvers = 4
 
     static func shared(forJS js: String) throws -> SignatureSolver {
         sharedLock.lock()
         defer { sharedLock.unlock() }
-        // Compare the retained player JS directly — Swift string equality is
+        // Match on the retained player JS directly — Swift string equality is
         // pointer-identity-fast in the common case and avoids the hash-collision
         // risk of caching by hashValue (a collision would return a wrong solver).
-        if let cached = sharedSolver, cached.playerJS == js {
-            return cached
+        if let idx = sharedSolvers.firstIndex(where: { $0.playerJS == js }) {
+            let solver = sharedSolvers.remove(at: idx)
+            sharedSolvers.insert(solver, at: 0) // promote to most-recently-used
+            return solver
         }
         // A task can be cancelled while blocked on the lock; bail before the
         // expensive init rather than tying up the thread pool.
@@ -39,7 +46,10 @@ class SignatureSolver {
         let start = Date()
         let solver = try SignatureSolver(js: js)
         os_log("solver init took %.2fs", log: log, type: .default, Date().timeIntervalSince(start))
-        sharedSolver = solver
+        sharedSolvers.insert(solver, at: 0)
+        if sharedSolvers.count > maxCachedSolvers {
+            sharedSolvers.removeLast()
+        }
         return solver
     }
 

--- a/Sources/YouTubeKit/SignatureSolver.swift
+++ b/Sources/YouTubeKit/SignatureSolver.swift
@@ -20,19 +20,26 @@ class SignatureSolver {
     // JavaScriptCore runs interpreted). Cache one solver per player-JS version so
     // subsequent videos reuse the context and the preprocessed player.
     private static let sharedLock = NSLock()
-    nonisolated(unsafe) private static var sharedSolver: (jsHash: Int, solver: SignatureSolver)?
+    nonisolated(unsafe) private static var sharedSolver: SignatureSolver?
 
     static func shared(forJS js: String) throws -> SignatureSolver {
-        let hash = js.hashValue
         sharedLock.lock()
         defer { sharedLock.unlock() }
-        if let cached = sharedSolver, cached.jsHash == hash {
-            return cached.solver
+        // Compare the retained player JS directly — Swift string equality is
+        // pointer-identity-fast in the common case and avoids the hash-collision
+        // risk of caching by hashValue (a collision would return a wrong solver).
+        if let cached = sharedSolver, cached.playerJS == js {
+            return cached
+        }
+        // A task can be cancelled while blocked on the lock; bail before the
+        // expensive init rather than tying up the thread pool.
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
+            try Task.checkCancellation()
         }
         let start = Date()
         let solver = try SignatureSolver(js: js)
         os_log("solver init took %.2fs", log: log, type: .default, Date().timeIntervalSince(start))
-        sharedSolver = (hash, solver)
+        sharedSolver = solver
         return solver
     }
 

--- a/Sources/YouTubeKit/YouTube.swift
+++ b/Sources/YouTubeKit/YouTube.swift
@@ -250,6 +250,10 @@ public class YouTube {
                         
                         do {
                             try await Extraction.applySignature(streamManifest: &streamManifest, videoInfo: videoInfo, js: js)
+                        } catch is CancellationError {
+                            // Cancellation is not a stale-JS failure — propagate it
+                            // immediately instead of clearing the cache and retrying.
+                            throw CancellationError()
                         } catch {
                             // to force an update to the js file, we clear the cache and retry
                             _js = nil


### PR DESCRIPTION
### Problem

`Extraction.applySignature` constructs a fresh `SignatureSolver` for **every** video: a new `JSContext`, re-evaluation of the meriyah/astring UMD bundles, and a full parse of the ~2 MB player JS on the first solve. On platforms where JavaScriptCore has no JIT (tvOS/iOS), that first parse dominates — it cost ~15 s per video in our measurements on Apple TV, paid again for every title.

Since the player JS changes only every few days, this work is almost entirely redundant across videos in a session.

### Fix

- `SignatureSolver.shared(forJS:)` caches one instance keyed by the player-JS hash and reuses it across videos.
- The first `batchSolve` requests `output_preprocessed` and stores the returned preprocessed player; subsequent solves send it back via the `preprocessed_player` input type and skip the full parse.
- Solves are serialized with a lock (a shared `JSContext` isn't thread-safe).
- `Task.checkCancellation()` runs before the expensive solver work so a cancelled extraction doesn't burn CPU.

### Measurements (Apple TV, tvOS)

| | before | after |
|---|---|---|
| first extraction of session | ~18–25 s | ~6 s (one-time parse) |
| subsequent extractions | ~18–25 s each | ~1.7–2.5 s |

### Verification

Builds clean across the CI matrix locally, including explicit Swift 6 language mode (`nonisolated(unsafe)` cache guarded by `NSLock`).

<!-- codex-pr-summary:start -->
---

> [!NOTE]
> **Overview** This PR reuses `SignatureSolver` instances across videos by caching solvers per player JavaScript source, reducing repeated `JSContext` setup and helper bundle evaluation.
>
> **Solver reuse** `SignatureSolver.shared(forJS:)` adds a bounded most-recently-used cache keyed by the retained player JS, with each solver also keeping the first returned `preprocessed_player` so later `batchSolve` calls can skip the full player parse.
>
> **Concurrency and cancellation** Shared solver access is protected with locks around the cache and per-solver JavaScript execution, and cancellation is checked before expensive solver setup or solving work.
>
> **Stream extraction behavior** `Extraction.applySignature` now uses the shared solver path, while `YouTube.streams` preserves cancellation as cancellation instead of treating it like a stale player JS failure that clears cached JS and retries.
<!-- codex-pr-summary:end -->
